### PR TITLE
移植 next label 标签

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -176,6 +176,8 @@ tag_plugins:
   # {% checkbox %}
   checkbox:
     interactive: false # enable interactive for user
+  mark:
+    light_bg_offset: 0 # adjust color brightness
   emoji:
     default: https://cdn.jsdelivr.net/gh/volantis-x/cdn-emoji/qq/%s.gif
     twemoji: https://cdn.jsdelivr.net/gh/twitter/twemoji/assets/svg/%s.svg

--- a/scripts/tags/index.js
+++ b/scripts/tags/index.js
@@ -6,3 +6,4 @@ const postTabs = require('./lib/tabs')(hexo);
 hexo.extend.tag.register('tabs', postTabs, true);
 hexo.extend.tag.register('subtabs', postTabs, true);
 hexo.extend.tag.register('subsubtabs', postTabs, true);
+hexo.extend.tag.register('mark', require('./lib/mark')(hexo));

--- a/scripts/tags/lib/mark.js
+++ b/scripts/tags/lib/mark.js
@@ -1,0 +1,13 @@
+/**
+ * mark.js | 基于Next https://theme-next.js.org/docs/tag-plugins/label
+ */
+
+'use strict';
+
+module.exports = ctx => function(args) {
+  const [classes = 'default', text = ''] = args.join(' ').split(' ');
+
+  if (!text) ctx.log.warn('mark text must be defined!');
+
+  return `<mark class="mark ${classes.trim()}">${text}</mark>`;
+};

--- a/source/css/_layout/tag-plugins/mark.styl
+++ b/source/css/_layout/tag-plugins/mark.styl
@@ -1,0 +1,34 @@
+$lbg = hexo-config('tag_plugins.mark.light_bg_offset') is a 'unit' ? unit(hexo-config('tag_plugins.mark.light_bg_offset'), '%') : 0;
+
+$note-types = 'gray' 'purple' 'blue' 'green' 'orange' 'yellow' 'red';
+
+$note-border = {
+  gray : #777,
+  purple : #6f42c1,
+  blue    : #428bca,
+  green : #5cb85c,
+  orange : #f0ad4e,
+  yellow: #FFFF00,
+  red  : #d9534f
+};
+
+$mark = {
+  gray : lighten(spin($note-border.gray, 0), 89% + $lbg),
+  purple : lighten(spin($note-border.purple, 10), 87% + $lbg),
+  blue    : lighten(spin($note-border.blue, -10), 86% + $lbg),
+  green : lighten(spin($note-border.green, 10), 85% + $lbg),
+  orange : lighten(spin($note-border.orange, 10), 83% + $lbg),
+  yellow : lighten(spin($note-border.yellow, 0), 70% + $lbg),
+  red  : lighten(spin($note-border.red, -10), 87% + $lbg)
+};
+
+mark {
+  padding: 0 2px;
+  border-radius: $border-block
+  color: var(--text-p1);
+  for $type in $note-types {
+    &.{$type} {
+      background-color: $mark[$type];
+    }
+  }
+}


### PR DESCRIPTION
移植 next label 标签，可进行行内文本高亮，仅支持文本，目前七种颜色：`gray` `purple` `blue` `green` `orange` `yellow` `red`，可使用 `tag_plugins.mark.light_bg_offset: -50` 调整颜色亮度。
写法示例：
```md
{% mark gray gray %}

{% mark purple purple %}

{% mark blue blue %}

{% mark green green %}

{% mark orange orange %}

{% mark yellow yellow %}

{% mark red red %}
```

效果：
![1629364898047.png](https://bu.dusays.com/2021/08/19/e0fb3637c6588.png)