### PR TITLE
修复input parameter is of type [object Array]问题

### DIFF
--- a/layout/_partial/sidebar/widgets/markdown.ejs
+++ b/layout/_partial/sidebar/widgets/markdown.ejs
@@ -9,7 +9,7 @@ function layoutDiv() {
       el += '<span class="name">' + item.title + '</span>';
     el += '</div>';
     el += '<div class="widget-body fs14">';
-      el += markdown(item.content);
+      el += markdown(item.content[0]);
     el += '</div>';
   el += '</div>';
   return el;


### PR DESCRIPTION
input parameter is of type [object Array], string expected，看了下db.json发现这个对象是个数组，就修了