### PR TITLE
feat: 在暗黑模式下反转 social icons，增加暗黑模式下黑色 icon 可见性

### DIFF
--- a/source/css/_layout/sidebar/footer.styl
+++ b/source/css/_layout/sidebar/footer.styl
@@ -13,6 +13,9 @@
     padding: 6px
     border-radius: 4px
     filter: grayscale(100%)
+    if hexo-config('style.darkmode') == 'auto'
+      @media (prefers-color-scheme: dark)
+        filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(288deg) brightness(102%) contrast(102%);
     overflow: hidden
     background: transparent
     trans3: box-shadow background transform


### PR DESCRIPTION
解决了 #69 描述的问题，同时能保证仍然只需要设置一套 icon（目前在dark下会反转，所以 icon 应设置为“黑色”的）