### PR TITLE
fix(plugin/heti): load stellar's JS code ASAP

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -62,15 +62,6 @@ function og_args() {
   <meta name="theme-color" content="#f8f8f8">
   <title><%- generate_title() %></title>
 
-  <% if (theme.heti) { %>
-    <link rel="stylesheet" href="//unpkg.com/heti/umd/heti.min.css">
-    <script src="//unpkg.com/heti/umd/heti-addon.min.js"></script>
-    <script defer>
-      const heti = new Heti('.heti');
-      heti.autoSpacing(); // 自动进行中西文混排美化和标点挤压
-    </script>
-  <% } %>
-
   <% if (theme.open_graph && theme.open_graph.enable) { %>
     <%- open_graph(og_args()) %>
   <% } %>

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -301,8 +301,22 @@ if (stellar.plugins.fancybox) {
 if (stellar.plugins.heti) {
   stellar.loadCSS(stellar.plugins.heti.css);
   stellar.loadScript(stellar.plugins.heti.js, { defer: true }).then(function () {
-    const heti = new Heti('.heti p');
-    heti.autoSpacing();
+    const heti = new Heti('.heti');
+    
+    // Copied from heti.autoSpacing() without DOMContentLoaded.
+    // https://github.com/sivan/heti/blob/eadee6a3b748b3b7924a9e7d5b395d4bce479c9a/js/heti-addon.js
+    //
+    // We managed to minimize the code modification to ensure .autoSpacing()
+    // is synced with upstream; therefore, we use `.bind()` to emulate the 
+    // behavior of .autoSpacing() so we can even modify almost no code.
+    void (function () {
+      const $$rootList = document.querySelectorAll(this.rootSelector)
+
+      for (let $$root of $$rootList) {
+        this.spacingElement($$root)
+      }
+    }).bind(heti)();
+
     stellar.plugins.heti.enable = false;
   });
 }


### PR DESCRIPTION
Heti 的 autoSpacing 是透過監聽 DOMContentLoaded 實作的——若採用 async 的載入方式，會導致註冊 autoSpacing 的 DOMContentLoaded handler 時，DOMContentLoaded 早已觸發完畢，亦即：.autoSpacing() 會失效。
