### PR TITLE
Add Rust & Rename TypeScript to TS

### DIFF
--- a/source/css/_common/highlight.styl
+++ b/source/css/_common/highlight.styl
@@ -154,8 +154,8 @@ article.md .highlight
     content: "Makefile"
   &.go .code:before
     content: "Go"
-  &.typescript .code:before
-    content: "TypeScript"
+  &.typescript .code:before,&.ts .code:before
+    content: "TS"
 
 
 

--- a/source/css/_common/highlight.styl
+++ b/source/css/_common/highlight.styl
@@ -144,7 +144,7 @@ article.md .highlight
     content: "Python"
   &.php .code:before
     content: "PHP"
-  &.rust .code:before
+  &.rust .code:before,&.rs .code:before
     content: "Rust"
   &.sql .code:before
     content: "SQL"


### PR DESCRIPTION
## Add Rust alias

Make `Rust` can be shown correctly when the code block is marked as `rs`.

<img width="714" alt="image" src="https://user-images.githubusercontent.com/28441561/183937756-9b76cead-8d52-467d-8a8a-eee3fcb3bc7b.png">

## Rename TypeScript to TS

To match which `js` appears as. Besides, `TypeScript` may be too long for some cases, imo. Besides, added `ts` as the alias of `TypeScript`.

<img width="757" alt="image" src="https://user-images.githubusercontent.com/28441561/183937620-fcea1d2d-51e5-48bb-8ee9-9b5e7ea9509e.png">

### Original

<img width="731" alt="image" src="https://user-images.githubusercontent.com/28441561/183938178-cc9337c6-e1e2-4c99-b562-2558446b30dd.png">

