### PR TITLE
升级 Waline 评论系统的自带表情

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -177,12 +177,13 @@ comments:
 
     # Custom emoji
     # emoji:
-    #   - https://unpkg.com/@waline/emojis@1.0.1/weibo
-    #   - https://unpkg.com/@waline/emojis@1.0.1/alus
-    #   - https://unpkg.com/@waline/emojis@1.0.1/bilibili
-    #   - https://unpkg.com/@waline/emojis@1.0.1/qq
-    #   - https://unpkg.com/@waline/emojis@1.0.1/tieba
-    #   - https://unpkg.com/@waline/emojis@1.0.1/tw-emoji
+    #   - https://unpkg.com/@waline/emojis@1.1.0/weibo
+    #   - https://unpkg.com/@waline/emojis@1.1.0/alus
+    #   - https://unpkg.com/@waline/emojis@1.1.0/bilibili
+    #   - https://unpkg.com/@waline/emojis@1.1.0/qq
+    #   - https://unpkg.com/@waline/emojis@1.1.0/tieba
+    #   - https://unpkg.com/@waline/emojis@1.1.0/tw-emoji
+    #   - https://unpkg.com/@waline/emojis@1.1.0/bmoji
 
     # Comment infomation, valid meta are nick, mail and link
     # meta:


### PR DESCRIPTION
将 Waline 评论系统的自带表情从 1.0.1 升级到了 1.1.0，并加入了新表情 “哔哩哔哩小黄脸”，可参考 https://waline.js.org/guide/client/emoji.html ，实测新版本表情包可用。