### PR TITLE
修改了文章页菜单栏url匹配逻辑

### DIFF
--- a/layout/_partial/main/navbar/list_post.ejs
+++ b/layout/_partial/main/navbar/list_post.ejs
@@ -39,11 +39,21 @@ function layoutDiv() {
   
   if (theme['post-index']) {
     const obj = theme['post-index'];
-    for (let key of Object.keys(obj)) {
-      if (full_url_for(page.path) == full_url_for(obj[key])) {
-        el += '<a class="active" href="' + url_for(obj[key]) + '">' + key + '</a>';
-      } else {
-        el += '<a href="' + url_for(obj[key]) + '">' + key + '</a>';
+    if (config.pretty_urls.trailing_index){
+      for (let key of Object.keys(obj)) {
+        if (full_url_for(page.path) == full_url_for(obj[key])+'index.html') {
+          el += '<a class="active" href="' + url_for(obj[key]) + '">' + key + '</a>';
+        } else {
+          el += '<a href="' + url_for(obj[key]) + '">' + key + '</a>';
+        }
+      }
+    }else{
+      for (let key of Object.keys(obj)) {
+        if (full_url_for(page.path) == full_url_for(obj[key])) {
+          el += '<a class="active" href="' + url_for(obj[key]) + '">' + key + '</a>';
+        } else {
+          el += '<a href="' + url_for(obj[key]) + '">' + key + '</a>';
+        }
       }
     }
   }


### PR DESCRIPTION
遇到了一些url的匹配问题。#146 
虽然两个配置有四种组合方式，但是尝试了一下发现只要考虑第一个好像都没问题了。（测试前都已`hexo clean`），希望作者审查一下代码谢谢啦