### PR TITLE
统一微信二维码分享链接

### DIFF
--- a/layout/_partial/main/article/article_footer.ejs
+++ b/layout/_partial/main/article/article_footer.ejs
@@ -99,7 +99,7 @@ function layoutDiv() {
       el += '</div>';
       if (theme.article.share.includes('wechat')) {
         el += '<div class="qrcode" id="qrcode-wechat" style="visibility:hidden;height:0">';
-        el += '<img src="https://api.qrserver.com/v1/create-qr-code/?size=256x256&data=' + url + '"/>';
+        el += '<img src="https://api.qrserver.com/v1/create-qr-code/?size=256x256&data=' + page.permalink + '"/>';
         el += '</div>';
       }
       el += '</div>';


### PR DESCRIPTION
## 问题描述
当设置如下时，微信二维码分享链接尾部会带 `index.html`（permalink 不带 index.html），与其他三种分享方式的链接不统一，且通过扫码进入的网页会是一个“新的”评论区：
```
pretty_urls: # 改写 permalink 的值来美化 URL
  trailing_index: false # 是否在永久链接中保留尾部的 index.html，设置为 false 时去除。
```
![image](https://user-images.githubusercontent.com/104631897/211311930-70ee011b-c329-42ab-9892-51d5dab063fc.png)
![image](https://user-images.githubusercontent.com/104631897/211312083-ff303c1c-d36c-4d4a-aca3-b89074d3dba2.png)
## 修改后
二维码分享链接无“新的”评论区这种现象：
![image](https://user-images.githubusercontent.com/104631897/211313518-1555bba6-dd5e-45e5-9119-930290445b8f.png)
且与其他三种分享方式的链接相统一：
![image](https://user-images.githubusercontent.com/104631897/211314375-b94cd067-3aa8-4d45-9372-c8158dbe68ca.png)
## 补充说明
经测试，当设置 permalink 带 index.html 时，修改后的二维码链接依旧表现正常，且与其他三种分享方式的链接相统一，不再赘述。






