### PR TITLE
Waline 新增图床为图片上传可选项

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -148,6 +148,26 @@ comments:
     #   - https://unpkg.com/@waline/emojis@1.1.0/tieba
     #   - https://unpkg.com/@waline/emojis@1.1.0/tw-emoji
     #   - https://unpkg.com/@waline/emojis@1.1.0/bmoji
+    # 设置自己的图床服务，替换默认的 Base 64 编码嵌入（有体积大小限制），在评论中上传图片更加方便
+    # imageUploader:
+      # 适配了兰空图床V1、V2版本
+      # 以兰空图床V1为例，下列填写内容为：
+      # fileName: file
+      # tokenName: Authorization
+      # url: https://xxxxxx/api/v1/upload
+      # token: Bearer xxxxxxxxxxxxxx
+      # resp: data.links.url
+      # 以兰空图床V2为例，下列填写内容为：
+      # fileName: image
+      # tokenName: token
+      # url: https://xxxxxx/api/upload
+      # token: xxxxxxxxxxxxxx
+      # resp: data.url
+    #   fileName: # 根据版本二选一
+    #   tokenName: # 根据版本二选一
+    #   api: # 图床 api 地址
+    #   token: # 图床验证
+    #   resp: # 图片地址返回值的字段
   
   # Artalk
   # https://artalk.js.org/

--- a/layout/_partial/plugins/comments/waline/script.ejs
+++ b/layout/_partial/plugins/comments/waline/script.ejs
@@ -11,6 +11,23 @@
       Waline.init(Object.assign(<%- JSON.stringify(theme.comments.waline) %>, {
         el: '#waline_container',
         path: path,
+        <% if(!!theme.comments.waline.imageUploader?.api){ %>
+          imageUploader: function(file) {
+            let headers = new Headers();
+            headers.set('Accept', 'application/json');
+            <% if(!!theme.comments.waline.imageUploader?.token) { %>
+              headers.set('<%= theme.comments.waline.imageUploader?.tokenName %>', '<%= theme.comments.waline.imageUploader?.token %>')
+            <% } %>
+            let formData = new FormData();
+            formData.append('<%= theme.comments.waline.imageUploader?.fileName %>', file);
+            return fetch('<%= theme.comments.waline.imageUploader?.api %>',{
+              method: 'POST',
+              body: formData,
+              headers: headers
+              }).then((resp) => resp.json())
+                .then((resp) => resp.<%= theme.comments.waline.imageUploader?.resp %>)
+          },
+        <% } %>
       }));
     });
   }


### PR DESCRIPTION
之前评论系统 Waline 只能使用 Base64 编码的方式上传图片，体积限制在 128 KB，略有不便。
故新增图床为图片上传可选项，适配了兰空图床V1、V2版本（两版本 Api 略有不同），可以有选择性地启用图床，或者使用默认的 Base64，皆测试运行正常。
![image](https://user-images.githubusercontent.com/104631897/211560033-d1bc9db3-7949-4e4c-8c6f-c4016fd60db9.png)
![image](https://user-images.githubusercontent.com/104631897/211560061-93c408e9-7276-40b6-8601-f277fde19f2e.png)
我目前选择的是兰空图床V2，可实际体验：[https://www.shifeiti.com/about/](https://www.shifeiti.com/about/)