### PR TITLE
[fix] loadScript, search

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ open_graph:
 
 
 ######## Sidebar ########
+root:
 sidebar:
   logo:
     avatar: '[config.avatar](/about/)' # you can set avatar link in _config.yml or '[https://xxx.png](/about/)'

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,6 @@ open_graph:
 
 
 ######## Sidebar ########
-root:
 sidebar:
   logo:
     avatar: '[config.avatar](/about/)' # you can set avatar link in _config.yml or '[https://xxx.png](/about/)'

--- a/_config.yml
+++ b/_config.yml
@@ -76,7 +76,6 @@ article:
 search:
   service: local_search # local_search, todo...
   local_search: # 在 front-matter 中设置 indexing:false 来避免被搜索索引
-    root: # 若部署在子目录才需填写, 如 https://blog.xxx.com/a/b 就填 /a/b 结尾不用斜杠
     field: all # post, page, all
     path: /search.json # 搜索文件存放位置
     content: true # 是否搜索内容

--- a/_config.yml
+++ b/_config.yml
@@ -76,6 +76,7 @@ article:
 search:
   service: local_search # local_search, todo...
   local_search: # 在 front-matter 中设置 indexing:false 来避免被搜索索引
+    root: # 若部署在子目录才需填写, 如 https://blog.xxx.com/a/b 就填 /a/b 结尾不用斜杠
     field: all # post, page, all
     path: /search.json # 搜索文件存放位置
     content: true # 是否搜索内容

--- a/layout/_partial/scripts/index.ejs
+++ b/layout/_partial/scripts/index.ejs
@@ -1,4 +1,5 @@
 <script type="text/javascript">
+
   const stellar = {
     // 懒加载 css https://github.com/filamentgroup/loadCSS
     loadCSS: (href, before, media, attributes) => {
@@ -62,8 +63,9 @@
     // 从 butterfly 和 volantis 获得灵感
     loadScript: (src, opt) => new Promise((resolve, reject) => {
       var script = document.createElement('script');
-      if (src.startsWith('/')){
-        src = '..' + src;
+      const config_root = '<%- config.root %>'.slice(0,-1);
+      if (src.startsWith('/') && config_root!==''){
+        src = config_root + src;
       }
       script.src = src;
       if (opt) {

--- a/layout/_partial/scripts/index.ejs
+++ b/layout/_partial/scripts/index.ejs
@@ -62,6 +62,9 @@
     // 从 butterfly 和 volantis 获得灵感
     loadScript: (src, opt) => new Promise((resolve, reject) => {
       var script = document.createElement('script');
+      if (src.startsWith('/')){
+        src = '..' + src;
+      }
       script.src = src;
       if (opt) {
         for (let key of Object.keys(opt)) {

--- a/layout/_partial/scripts/index.ejs
+++ b/layout/_partial/scripts/index.ejs
@@ -62,9 +62,8 @@
     // 从 butterfly 和 volantis 获得灵感
     loadScript: (src, opt) => new Promise((resolve, reject) => {
       var script = document.createElement('script');
-      const config_root = '<%- config.root %>'.slice(0,-1);
-      if (src.startsWith('/') && config_root!==''){
-        src = config_root + src;
+      if (src.startsWith('/') && stellar.site_root!==''){
+        src = stellar.site_root + src;
       }
       script.src = src;
       if (opt) {
@@ -94,6 +93,7 @@
       }
     }
   };
+  stellar.site_root = '<%- config.root %>'.slice(0,-1);
   stellar.version = '<%- theme.stellar.version %>';
   stellar.github = 'https://github.com/xaoxuu/hexo-theme-stellar/tree/<%- theme.stellar.version %>';
   stellar.config = {

--- a/layout/_partial/scripts/index.ejs
+++ b/layout/_partial/scripts/index.ejs
@@ -1,5 +1,4 @@
 <script type="text/javascript">
-
   const stellar = {
     // 懒加载 css https://github.com/filamentgroup/loadCSS
     loadCSS: (href, before, media, attributes) => {

--- a/layout/_partial/scripts/index.ejs
+++ b/layout/_partial/scripts/index.ejs
@@ -62,8 +62,8 @@
     // 从 butterfly 和 volantis 获得灵感
     loadScript: (src, opt) => new Promise((resolve, reject) => {
       var script = document.createElement('script');
-      if (src.startsWith('/') && stellar.site_root!==''){
-        src = stellar.site_root + src;
+      if (src.startsWith('/')){
+        src = stellar.config.root + src.substring(1);
       }
       script.src = src;
       if (opt) {
@@ -93,7 +93,6 @@
       }
     }
   };
-  stellar.site_root = '<%- config.root %>'.slice(0,-1);
   stellar.version = '<%- theme.stellar.version %>';
   stellar.github = 'https://github.com/xaoxuu/hexo-theme-stellar/tree/<%- theme.stellar.version %>';
   stellar.config = {
@@ -104,6 +103,7 @@
       day: '<%- __('meta.date_suffix.day') %>',
       month: '<%- __('meta.date_suffix.month') %>',
     },
+    root : '<%- config.root %>',
   };
 
   // required plugins (only load if needs)

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -337,9 +337,9 @@ if (stellar.search.service) {
           if (!path.startsWith('/')) {
             path = '/' + path;
           }
-          const siteRoot = stellar.search.local_search.root;
-          if (siteRoot){
-            path = siteRoot + path;
+          const search_root = stellar.search.local_search.root;
+          if (search_root){
+            path = search_root + path;
           }
           const filter = $inputArea.attr('data-filter') || '';
           searchFunc(path, filter, 'search-input', 'search-result');

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -337,6 +337,10 @@ if (stellar.search.service) {
           if (!path.startsWith('/')) {
             path = '/' + path;
           }
+          const siteRoot = stellar.search.local_search.root;
+          if (siteRoot){
+            path = siteRoot + path;
+          }
           const filter = $inputArea.attr('data-filter') || '';
           searchFunc(path, filter, 'search-input', 'search-result');
         });

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -334,10 +334,10 @@ if (stellar.search.service) {
         var $resultArea = document.querySelector("div#search-result");
         $inputArea.focus(function() {
           var path = stellar.search[stellar.search.service]?.path || '/search.json';
-          if (!path.startsWith('/')) {
-            path = '/' + path;
+          if (path.startsWith('/')) {
+            path = path.substring(1);
           }
-          path = stellar.site_root + path;
+          path = stellar.config.root + path;
           const filter = $inputArea.attr('data-filter') || '';
           searchFunc(path, filter, 'search-input', 'search-result');
         });

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -337,10 +337,7 @@ if (stellar.search.service) {
           if (!path.startsWith('/')) {
             path = '/' + path;
           }
-          const search_root = stellar.search.local_search.root;
-          if (search_root){
-            path = search_root + path;
-          }
+          path = stellar.site_root + path;
           const filter = $inputArea.attr('data-filter') || '';
           searchFunc(path, filter, 'search-input', 'search-result');
         });


### PR DESCRIPTION
## 问题
目前如果站点部署在多级目录下, loadScript会丢失很多js, search.json也会丢失
![image](https://user-images.githubusercontent.com/43780818/218299840-53c3097d-78b2-4aed-b7fd-515c185f6c60.png)

## loadScript修复
丢失的JS思路是修复js的引用方法`loadScript`
在script的src添加'<%- config.root %>'可以基于站点目录申请资源,  而非直接去域名下申请资源.
`<script src="/js/xxx.js"></script>`  to  `<script src="/部署目录/js/xxx.js"></script>`


## search修复
获取search.json文件不在ejs不能使用hexo全局变量url, 我只能想到主题配置search.local_search下增加一个root来配置资源位置.