### PR TITLE
增加 keywords

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -37,6 +37,17 @@ function generate_description() {
   }
   return '<meta name="description" content="' + config.description + '">';
 }
+function generate_keywords() {
+  if (page.keywords && page.keywords.length > 0) {
+    return '<meta name="keywords" content="' + page.keywords + '">';
+  } else if (page.tags && page.tags.length > 0) {
+    return '<meta name="keywords" content="' + page.tags.map(tag => tag.name).join(',') + '">';
+  } else if (config.keywords && config.keywords.length > 0) {
+    return '<meta name="keywords" content="' + config.keywords + '">';
+  } else {
+    return '';
+  }
+}
 
 function generate_robots() {
   if (is_home() == true) {
@@ -82,6 +93,8 @@ function og_args() {
     <%- open_graph(og_args()) %>
   <% } %>
   <%- generate_description() %>
+  
+  <%- generate_keywords() %>
 
   <!-- feed -->
   <% if (config.feed && config.feed.path) { %>


### PR DESCRIPTION
解决 [issue](https://github.com/xaoxuu/hexo-theme-stellar/issues/278)，增加 keywords，支持多种设置方法。

## 优先级

front-matter 中设置的 `keywords` > front-matter 中设置的 `tags` > 根目录下 _config.yml 中设置的 `keywords` > 返回空字符串

## 示例

### front-matter 中设置 keywords

```
---
tags: [tag1, tag2, Tag3]
keywords: keyword1,Keyword2,keyword3
---
```

结果：

```
<meta name="keywords" content="keyword1,Keyword2,keyword3">
```

### front-matter 中只设置 tags

```
tags: [tag1, tag2, Tag3]
```

结果：

```
<meta name="keywords" content="tag1,tag2,Tag3">
```

或

```
---
tags:
  - Tag1
  - tag2
  - Tag3
---
 ```
结果：

```
<meta name="keywords" content="Tag1,tag2,Tag3">
```

### _config.yml 中设置 keywords

对应无法自定义 front-matter 及 front-matter 中未设置 keywords、tags 的这两种页面。

```
keywords: K1,k2,k3
```

结果：

```
<meta name="keywords" content="K1,k2,k3">
```