### PR TITLE
✨[feat] markdown title作为图片标题

### DIFF
--- a/scripts/filters/index.js
+++ b/scripts/filters/index.js
@@ -5,7 +5,10 @@ hexo.extend.filter.register('after_render:html', require('./lib/img_onerror').pr
 
 function change_image(data) {
     if (this.theme.config.tag_plugins.image.parse_markdown) {
-      data.content = data.content.replace(/!\[([^\]]*)]\(([^(]+)\)/g, '{% image $2 $1 %}');
+      data.content = data.content.replace(
+          /!\[(.*?)\]\((.*?)\s*(?:"(.*?)")?\)/g,
+          '{% image $2 $3 %}'
+      );
     }
     return data;
 }


### PR DESCRIPTION
## 为什么要修改？

个人不建议 markdown 图片 alt 文本作为图片标题，很多笔记软件都是会自动填充 alt 文本的（比如 Typora），个人认为 alt 文本更适合在图片丢失或无网络情况下用来提示此处有图片。而目前语雀、思源笔记等笔记软件，都是以 markdown 图片 title 作为图片标题的。

## 修改内容

scripts\filters\index.js 修改 markdown 图片解析规则：解析 alt 文本为图片标题改为解析 title 文本为图片标题
