### PR TITLE
[opt] navbar, sidebar-list, footer

### DIFF
--- a/source/css/_layout/partial/footer.styl
+++ b/source/css/_layout/partial/footer.styl
@@ -3,7 +3,8 @@
   color: var(--text-p2)
   a
     color: var(--text-p2)
-    border-radius: 2px
+    border-radius: 4px
+    transition: background 0.2s ease-out
     &:hover
       color: var(--text)
       background: var(--block-hover)

--- a/source/css/_layout/sidebar/menu.styl
+++ b/source/css/_layout/sidebar/menu.styl
@@ -49,5 +49,5 @@
       transform: translateX(-50%)
       border-radius: 2px
       bottom: 2px
-      background: var(--text-p1)
+      background: currentColor
 

--- a/source/css/_layout/widgets/list.styl
+++ b/source/css/_layout/widgets/list.styl
@@ -1,6 +1,5 @@
 .widget-wrapper.post-list .widget-body
   a
-    line-height: 1
     font-size: $fs-14
     padding: 8px 16px
     display: block


### PR DESCRIPTION
- 修复侧边栏最近文章列表的行高
  - 现在诸如`g` `y`等字符也能完整显示了，而不是底部被裁切
- 美化navbar中高亮(active)元素的样式
  - 侧边栏的导航栏中，图标底部的下划线具有和图标相同的颜色，而不是普通文本颜色
- 增加了页脚sitemap元素的圆角大小
  - 具有和主页顶部导航栏、超链接相同的值(4px)