### PR TITLE
[fix] tianli_gpt layout

### DIFF
--- a/layout/_plugins/tianli_gpt.ejs
+++ b/layout/_plugins/tianli_gpt.ejs
@@ -1,4 +1,7 @@
-<% if (['all', page.layout].includes(theme.plugins.tianli_gpt.field)) { %>
+<% 
+const { field } = theme.plugins.tianli_gpt;
+const matchesField = field === 'all' || field === layout || (field === 'wiki' && page.wiki) || (field === 'topic' && page.topic);
+if (matchesField) { %>
   <script defer src="<%- theme.plugins.tianli_gpt?.js %>"></script>
   <script defer>
     window.addEventListener('DOMContentLoaded', (event) => {


### PR DESCRIPTION
wiki项目的 `layout` 变成了 `page` 导致GPT `field` 参数设置 `wiki` 失效