### PR TITLE
fix(stellar-artalk): bump version, fix site name escape

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -250,8 +250,8 @@ comments:
   # Artalk
   # https://artalk.js.org/
   artalk:
-    css: https://unpkg.com/artalk@2.7/dist/Artalk.css
-    js: https://unpkg.com/artalk@2.7/dist/Artalk.js
+    css: https://unpkg.com/artalk@2.8.5/dist/Artalk.css
+    js: https://unpkg.com/artalk@2.8.5/dist/Artalk.js
     server: # 后端服务地址
     placeholder: ''
     darkMode: auto

--- a/layout/_partial/comments/artalk/script.ejs
+++ b/layout/_partial/comments/artalk/script.ejs
@@ -14,7 +14,7 @@
         pageTitle: '<%= page.title %>',
         server: '<%= theme.comments.artalk.server %>',
         placeholder: '<%= theme.comments.artalk.placeholder %>',
-        site: '<%= config.title %>',
+        site: "<%- config.title %>",
         darkMode: '<%= theme.comments.artalk.darkMode %>'
         })
       });


### PR DESCRIPTION
修复以下问题：
1、低版本的 artalk js 无法对接高版本的 artalk 后端，升级配置文件中的版本；
2、模板中向 artalk 传递 site 名称使用了 `<%=` 转义会导致 artalk 无法对应站点，改用 `<%-` 解决。

例如我的博客名叫 `Frytea's Blog` ，但是在 artalk 看到请求的是类似 `Frytea&#39;s Blog` 导致 artalk 无法找到对应名字的站点，最终得到 404 错误。

```bash
Error: 未找到站点：`Frytea&#39;s Blog`，请在控制台创建站点
```

- references: ejs docs: https://ejs.co/#install

---

Fix the following issues:
1. Older versions of artalk js cannot connect to newer versions of artalk backend, upgrade the version in the configuration file;
2. Passing the site name to artalk in templates using `<%=` for escaping will cause artalk to not recognize the site correctly, use `<%-` instead.

For example, if my blog is named 'Frytea's Blog', but in artalk I see requests like 'Frytea&#39;s Blog', which causes artalk to be unable to find the corresponding site name, resulting in a 404 error.