### PR TITLE
[fix] render article footer in wiki pages

### DIFF
--- a/layout/page.ejs
+++ b/layout/page.ejs
@@ -40,7 +40,7 @@ function layoutDiv() {
   if (page.content && page.content.length > 0) {
     el += page.content
   }
-  if (layout === 'post') {
+  if (layout === 'post' || page.wiki) {
     el += partial('_partial/main/article/article_footer')
   }
   el += `</article>`


### PR DESCRIPTION
在文档 <https://xaoxuu.com/wiki/stellar/wiki-settings/> 中提到，wiki 页面可以设置显示 license 或 分享，但按照文档设置后并无法显示出来。

此 PR 修复该问题。