### PR TITLE
[fix] fix typo - missing `;` for `&quot;`

### DIFF
--- a/layout/_partial/main/article/article_footer.ejs
+++ b/layout/_partial/main/article/article_footer.ejs
@@ -99,7 +99,7 @@ function layoutDiv() {
             el += ' target="_blank" rel="external nofollow noopener noreferrer"';
           }
           if (item == 'wechat') {
-            el += ' onclick="util.toggle(&quot;qrcode-wechat&quot)"';
+            el += ' onclick="util.toggle(&quot;qrcode-wechat&quot;)"';
           } else if (item == 'weibo') {
             el += ' href="https://service.weibo.com/share/share.php?url=' + page.permalink;
             el += '&title=' + page.title + ' - ' + config.title;


### PR DESCRIPTION
`article_footer` 里 wechat 分享按钮的地方，`&quot;` 少写了一个分号。此 PR 修复该问题。

这个问题会导致通过 terser 对 html 内的 js 压缩的时候语法解析失败。

复现方式：

在 `_config.stellar.yml` 中 `article.share` 配置中确保添加了 `wechat`，开启 wechat 分享按钮。

以基于 `@uiolee/hexo-htmlnano` 插件为例，对构建物进行压缩：

``` bash
pnpm add @uiolee/hexo-htmlnano cssnano postcss terser svgo
hexo generate
```

进行压缩的时候，terser 会报错：

``` log
SyntaxError: Unterminated string constant
    at js_error (/node_modules/.pnpm/terser@5.31.0/node_modules/terser/dist/bundle.min.js:536:11)
    at parse_error (/node_modules/.pnpm/terser@5.31.0/node_modules/terser/dist/bundle.min.js:672:9)
    at /node_modules/.pnpm/terser@5.31.0/node_modules/terser/dist/bundle.min.js:1043:36
    at Object.next_token [as input] (/node_modules/.pnpm/terser@5.31.0/node_modules/terser/dist/bundle.min.js:1076:40)
    ......
```

并导致所有开启了 wechat 分享按钮的页面压缩后的 html 代码均为空。
