### PR TITLE
add comment loading button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -207,6 +207,7 @@ search:
 comments:
   service: # beaudar, utterances, giscus, twikoo, waline, artalk
   comment_title: 快来参与讨论吧~
+  load_button: false # true / false
   # beaudar
   # https://beaudar.lipk.org/
   beaudar:

--- a/layout/_partial/comments/artalk/script.ejs
+++ b/layout/_partial/comments/artalk/script.ejs
@@ -1,5 +1,5 @@
 <script>
-  function load_artalk() {
+  function load_comment() {
     if (!document.querySelectorAll("#artalk_container")[0]) return;
     utils.css('<%- theme.comments.artalk.css %>');
     utils.js('<%- theme.comments.artalk.js %>', {defer: true}).then(function () {
@@ -19,7 +19,4 @@
         })
       });
   }
-  window.addEventListener('DOMContentLoaded', (event) => {
-    load_artalk();
-  });
 </script>

--- a/layout/_partial/comments/beaudar/script.ejs
+++ b/layout/_partial/comments/beaudar/script.ejs
@@ -1,5 +1,5 @@
 <script>
-  function loadBeaudar() {
+  function load_comment() {
     const els = document.querySelectorAll("#comments #beaudar");
     if (els.length === 0) return;
     els.forEach((el, i) => {
@@ -20,7 +20,4 @@
       el.appendChild(script);
     });
   }
-  window.addEventListener('DOMContentLoaded', (event) => {
-      loadBeaudar();
-  });
 </script>

--- a/layout/_partial/comments/giscus/script.ejs
+++ b/layout/_partial/comments/giscus/script.ejs
@@ -1,5 +1,5 @@
 <script>
-  window.addEventListener('DOMContentLoaded', (event) => {
+  function load_comment() {
     const els = document.querySelectorAll("#comments #giscus");
     if (els.length === 0) return;
     els.forEach((el, i) => {
@@ -18,5 +18,5 @@
       }
       el.appendChild(script);
     });
-  });
+  }
 </script>

--- a/layout/_partial/comments/layout.ejs
+++ b/layout/_partial/comments/layout.ejs
@@ -62,7 +62,7 @@ page.cmt = cmt;
     <button type="button" onclick="appear_comment()" id="comment-load-button">
       <svg role="img" xmlns="http://www.w3.org/2000/svg" width="25px" height="25px" viewBox="0 0 24 24" aria-labelledby="chatIconTitle" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" fill="none"> <path d="M8.82388455,18.5880577 L4,21 L4.65322944,16.4273939 C3.00629211,15.0013 2,13.0946628 2,11 C2,6.581722 6.4771525,3 12,3 C17.5228475,3 22,6.581722 22,11 C22,15.418278 17.5228475,19 12,19 C10.8897425,19 9.82174472,18.8552518 8.82388455,18.5880577 Z"/> </svg>
       <p>
-        加载聊天框
+        加载评论区？
       </p>
     </button>
   <% } %>

--- a/layout/_partial/comments/layout.ejs
+++ b/layout/_partial/comments/layout.ejs
@@ -33,10 +33,24 @@ if (loadComment && (proj != null)) {
 if (cmt.service && page[cmt.service]) {
   Object.assign(cmt[cmt.service], page[cmt.service]);
 }
+if (loadComment) {
+  if (page.comments != undefined && page.comments.load_button != undefined) {
+    cmt.load_button = page.comments.load_button;
+  } else if (proj != null && proj.comments != undefined && proj.comments.load_button != undefined) {
+    cmt.load_button = proj.comments.load_button;
+  } else if (theme.comments != undefined && theme.comments.load_button != undefined) {
+    cmt.load_button = theme.comments.load_button;
+  }
+  
+  if (cmt.load_button != true) {
+    cmt.load_button = false;
+  }
+}
+
 page.cmt = cmt;
 %>
 <% if (loadComment) { %>
-  <div class="related-wrap md-text<%- scrollreveal(' ') %>" id="comments">
+  <div class="related-wrap md-text<%- scrollreveal(' ') %>" id="comments" <% if (page.cmt.load_button) { %>style="display:none"<% } %>>
     <section class='header cmt-title cap theme'>
       <%- markdown(page.comment_title || theme.comments.comment_title) %>
     </section>
@@ -44,4 +58,12 @@ page.cmt = cmt;
       <%- partial(cmt.service + '/layout') %>
     </section>
   </div>
+  <% if (page.cmt.load_button) { %>
+    <button type="button" onclick="appear_comment()" id="comment-load-button">
+      <svg role="img" xmlns="http://www.w3.org/2000/svg" width="25px" height="25px" viewBox="0 0 24 24" aria-labelledby="chatIconTitle" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" fill="none"> <path d="M8.82388455,18.5880577 L4,21 L4.65322944,16.4273939 C3.00629211,15.0013 2,13.0946628 2,11 C2,6.581722 6.4771525,3 12,3 C17.5228475,3 22,6.581722 22,11 C22,15.418278 17.5228475,19 12,19 C10.8897425,19 9.82174472,18.8552518 8.82388455,18.5880577 Z"/> </svg>
+      <p>
+        加载聊天框
+      </p>
+    </button>
+  <% } %>
 <% } %>

--- a/layout/_partial/comments/script.ejs
+++ b/layout/_partial/comments/script.ejs
@@ -1,3 +1,18 @@
 <% if (page.cmt && page.cmt.service && page.cmt.service.length > 0) { %>
   <%- partial(page.cmt.service + '/script') %>
+  <script>
+    <% if (page.cmt.load_button) { %>
+      function appear_comment() {
+        let div = document.getElementById("comments");
+        div.style="";
+        load_comment();
+        let self = document.getElementById("comment-load-button");
+        self.remove();
+      }
+    <% } else { %>
+      window.addEventListener('DOMContentLoaded', (event) => {
+        load_comment();
+      });
+    <% } %>
+  </script>
 <% } %>

--- a/layout/_partial/comments/twikoo/script.ejs
+++ b/layout/_partial/comments/twikoo/script.ejs
@@ -1,20 +1,16 @@
 <script>
-    function load_twikoo() {
-        if (!document.querySelectorAll("#twikoo_container")[0]) return;
-        utils.js('<%- theme.comments.twikoo.js %>', {defer: true}).then(function () {
-            const el = document.getElementById("twikoo_container");
-            var path = el.getAttribute('comment_id');
-            if (!path) {
-                path = decodeURI(window.location.pathname);
-            }
-            twikoo.init(Object.assign(<%- JSON.stringify(theme.comments.twikoo) %>, {
-                el: '#twikoo_container',
-                path: path,
-            }));
-        });
-    }
-
-    window.addEventListener('DOMContentLoaded', (event) => {
-        load_twikoo();
+  function load_comment() {
+    if (!document.querySelectorAll("#twikoo_container")[0]) return;
+    utils.js('<%- theme.comments.twikoo.js %>', {defer: true}).then(function () {
+      const el = document.getElementById("twikoo_container");
+      var path = el.getAttribute('comment_id');
+      if (!path) {
+        path = decodeURI(window.location.pathname);
+      }
+      twikoo.init(Object.assign(<%- JSON.stringify(theme.comments.twikoo) %>, {
+        el: '#twikoo_container',
+        path: path,
+      }));
     });
+  }
 </script>

--- a/layout/_partial/comments/utterances/script.ejs
+++ b/layout/_partial/comments/utterances/script.ejs
@@ -1,5 +1,5 @@
 <script>
-  function loadUtterances() {
+  function load_comment(){
     const els = document.querySelectorAll("#comments #utterances");
     if (els.length === 0) return;
     els.forEach((el, i) => {
@@ -20,7 +20,4 @@
       el.appendChild(script);
     });
   }
-  window.addEventListener('DOMContentLoaded', (event) => {
-      loadUtterances();
-  });
 </script>

--- a/layout/_partial/comments/waline/script.ejs
+++ b/layout/_partial/comments/waline/script.ejs
@@ -36,8 +36,4 @@
     }));
 
   }
-  window.addEventListener('DOMContentLoaded', (event) => {
-    load_comment();
-  });
-
 </script>

--- a/source/css/_plugins/comments/load-button.styl
+++ b/source/css/_plugins/comments/load-button.styl
@@ -1,0 +1,28 @@
+#comment-load-button
+  background-color: rgba($color-theme, 0.2)
+  color: $color-theme
+  padding: 10px 20px 10px 20px
+  text-align: center
+  text-decoration: none
+  display: block
+  margin: 4px 2px
+  cursor: pointer
+  border-radius: 8px
+  border: solid 2px rgba($color-theme, 0.2)
+  transition-duration: 0.4s
+  align-items: center
+  justify-content: center
+  display: flex
+
+#comment-load-button:hover 
+  border: solid 2px $color-hover
+
+#comment-load-button svg
+  display flex
+  stroke darken($color-theme, 40%)
+
+#comment-load-button p
+  display flex
+  --fsp: $fsp2
+  font-size: var(--fsp)
+  margin: 0

--- a/source/css/_plugins/index.styl
+++ b/source/css/_plugins/index.styl
@@ -30,3 +30,5 @@ if hexo-config('comments.service') == 'waline'
   @import 'comments/waline'
 if hexo-config('comments.service') == 'artalk'
   @import 'comments/artalk'
+if hexo-config('comments.service') != undefined && hexo-config('comments.load_button') == true
+  @import 'comments/load-button'


### PR DESCRIPTION
## 问题
评论区不能没有，但不一定会看评论区。尤其是在项目文档中，看一个项目可能就翻一次评论区。在编写文章的时候，如果是用的浏览器实时渲染页面，下面评论区一直加载也很恼火。
## 修改后效果
1. 隐藏评论区位置。
1. 添加一个button。按下后取消评论区的隐藏，开始加载评论区。
1. 以上当且仅当配置`comments.load_button`为`true`是启用。默认为`false`。
## 可能的不足
样式不怎么好看。颜色跟随主题色（主题色为白色就愕愕了）。
页面效果：
![2024-05-30 10-20-06 的屏幕截图](https://cdn.ipfsscan.io/weibo/large/008D5oyhly1hq7bso0obaj30jm0qtgof.jpg)