### PR TITLE
feat: 评论区视口懒加载

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -207,6 +207,7 @@ search:
 comments:
   service: # beaudar, utterances, giscus, twikoo, waline, artalk
   comment_title: 快来参与讨论吧~
+  viewportLazyload: false # true / false
   # beaudar
   # https://beaudar.lipk.org/
   beaudar:

--- a/_config.yml
+++ b/_config.yml
@@ -207,7 +207,7 @@ search:
 comments:
   service: # beaudar, utterances, giscus, twikoo, waline, artalk
   comment_title: 快来参与讨论吧~
-  viewportLazyload: false # true / false
+  lazyload: false # true / false
   # beaudar
   # https://beaudar.lipk.org/
   beaudar:

--- a/layout/_partial/comments/artalk/script.ejs
+++ b/layout/_partial/comments/artalk/script.ejs
@@ -1,6 +1,6 @@
 <script type="module">
   const el = document.getElementById('artalk_container');
-  util.viewportLazyload(el, load_artalk, <%= theme.comments.viewportLazyload %>);
+  util.viewportLazyload(el, load_artalk, <%= theme.comments.lazyload %>);
 
   function load_artalk() {
     if (!el) return;

--- a/layout/_partial/comments/artalk/script.ejs
+++ b/layout/_partial/comments/artalk/script.ejs
@@ -1,14 +1,16 @@
-<script>
+<script type="module">
+  const el = document.getElementById('artalk_container');
+  util.viewportLazyload(el, load_artalk, <%= theme.comments.viewportLazyload %>);
+
   function load_artalk() {
-    if (!document.querySelectorAll("#artalk_container")[0]) return;
+    if (!el) return;
     utils.css('<%- theme.comments.artalk.css %>');
     utils.js('<%- theme.comments.artalk.js %>', {defer: true}).then(function () {
-      const el = document.getElementById("artalk_container");
-      var path = el.getAttribute('comment_id');
+      const path = el.getAttribute('comment_id');
       if (!path) {
         path = decodeURI(window.location.pathname);
       }
-      var artalk = Artalk.init({
+      const artalk = Artalk.init({
         el: '#artalk_container',
         pageKey: path,
         pageTitle: '<%= page.title %>',
@@ -16,10 +18,7 @@
         placeholder: '<%= theme.comments.artalk.placeholder %>',
         site: "<%- config.title %>",
         darkMode: '<%= theme.comments.artalk.darkMode %>'
-        })
       });
+    });
   }
-  window.addEventListener('DOMContentLoaded', (event) => {
-    load_artalk();
-  });
 </script>

--- a/layout/_partial/comments/artalk/script.ejs
+++ b/layout/_partial/comments/artalk/script.ejs
@@ -1,6 +1,6 @@
 <script type="module">
   const el = document.getElementById('artalk_container');
-  util.viewportLazyload(el, load_artalk, <%= theme.comments.lazyload %>);
+  util.viewportLazyload(el, load_artalk, <%= theme.comments.lazyload ?? false %>);
 
   function load_artalk() {
     if (!el) return;

--- a/layout/_partial/comments/beaudar/script.ejs
+++ b/layout/_partial/comments/beaudar/script.ejs
@@ -1,26 +1,23 @@
-<script>
-  function loadBeaudar() {
-    const els = document.querySelectorAll("#comments #beaudar");
-    if (els.length === 0) return;
-    els.forEach((el, i) => {
-      try {
-        el.innerHTML = '';
-      } catch (error) {
-        console.error(error);
+<script type="module">
+  const el = document.querySelector('#comments #beaudar');
+  util.viewportLazyload(el, load_beaudar, <%= theme.comments.viewportLazyload %>);
+
+  function load_beaudar() {
+    if (!el) return;
+    try {
+      el.innerHTML = '';
+    } catch (error) {
+      console.error(error);
+    }
+    const script = document.createElement('script');
+    script.src = 'https://beaudar.lipk.org/client.js';
+    script.async = true;
+    for (const key of Object.keys(el.attributes)) {
+      const attr = el.attributes[key];
+      if (['class', 'id'].includes(attr.name) === false) {
+        script.setAttribute(attr.name, attr.value);
       }
-      var script = document.createElement('script');
-      script.src = 'https://beaudar.lipk.org/client.js';
-      script.async = true;
-      for (let key of Object.keys(el.attributes)) {
-        let attr = el.attributes[key];
-        if (['class', 'id'].includes(attr.name) === false) {
-          script.setAttribute(attr.name, attr.value);
-        }
-      }
-      el.appendChild(script);
-    });
+    }
+    el.appendChild(script);
   }
-  window.addEventListener('DOMContentLoaded', (event) => {
-      loadBeaudar();
-  });
 </script>

--- a/layout/_partial/comments/beaudar/script.ejs
+++ b/layout/_partial/comments/beaudar/script.ejs
@@ -1,6 +1,6 @@
 <script type="module">
   const el = document.querySelector('#comments #beaudar');
-  util.viewportLazyload(el, load_beaudar, <%= theme.comments.lazyload %>);
+  util.viewportLazyload(el, load_beaudar, <%= theme.comments.lazyload ?? false %>);
 
   function load_beaudar() {
     if (!el) return;

--- a/layout/_partial/comments/beaudar/script.ejs
+++ b/layout/_partial/comments/beaudar/script.ejs
@@ -1,6 +1,6 @@
 <script type="module">
   const el = document.querySelector('#comments #beaudar');
-  util.viewportLazyload(el, load_beaudar, <%= theme.comments.viewportLazyload %>);
+  util.viewportLazyload(el, load_beaudar, <%= theme.comments.lazyload %>);
 
   function load_beaudar() {
     if (!el) return;

--- a/layout/_partial/comments/giscus/script.ejs
+++ b/layout/_partial/comments/giscus/script.ejs
@@ -1,22 +1,22 @@
-<script>
-  window.addEventListener('DOMContentLoaded', (event) => {
-    const els = document.querySelectorAll("#comments #giscus");
-    if (els.length === 0) return;
-    els.forEach((el, i) => {
-      try {
+<script type="module">
+  const el = document.querySelector('#comments #giscus');
+  util.viewportLazyload(el, load_discus, <%= theme.comments.viewportLazyload %>);
+
+  function load_discus() {
+    if (!el) return;
+    try {
         el.innerHTML = '';
       } catch (error) {
         console.error(error);
       }
-      var script = document.createElement('script');
+      const script = document.createElement('script');
       script.async = true;
-      for (let key of Object.keys(el.attributes)) {
-        let attr = el.attributes[key];
+      for (const key of Object.keys(el.attributes)) {
+        const attr = el.attributes[key];
         if (['class', 'id'].includes(attr.name) === false) {
           script.setAttribute(attr.name, attr.value);
         }
       }
       el.appendChild(script);
-    });
-  });
+  }
 </script>

--- a/layout/_partial/comments/giscus/script.ejs
+++ b/layout/_partial/comments/giscus/script.ejs
@@ -1,6 +1,6 @@
 <script type="module">
   const el = document.querySelector('#comments #giscus');
-  util.viewportLazyload(el, load_discus, <%= theme.comments.viewportLazyload %>);
+  util.viewportLazyload(el, load_discus, <%= theme.comments.lazyload %>);
 
   function load_discus() {
     if (!el) return;

--- a/layout/_partial/comments/giscus/script.ejs
+++ b/layout/_partial/comments/giscus/script.ejs
@@ -1,6 +1,6 @@
 <script type="module">
   const el = document.querySelector('#comments #giscus');
-  util.viewportLazyload(el, load_discus, <%= theme.comments.lazyload %>);
+  util.viewportLazyload(el, load_discus, <%= theme.comments.lazyload ?? false %>);
 
   function load_discus() {
     if (!el) return;

--- a/layout/_partial/comments/twikoo/script.ejs
+++ b/layout/_partial/comments/twikoo/script.ejs
@@ -1,6 +1,6 @@
 <script type="module">
   const el = document.getElementById('artalk_container');
-  util.viewportLazyload(el, load_twikoo, <%= theme.comments.viewportLazyload %>);
+  util.viewportLazyload(el, load_twikoo, <%= theme.comments.lazyload %>);
 
   function load_twikoo() {
     if (!el) return;

--- a/layout/_partial/comments/twikoo/script.ejs
+++ b/layout/_partial/comments/twikoo/script.ejs
@@ -1,6 +1,6 @@
 <script type="module">
   const el = document.getElementById('artalk_container');
-  util.viewportLazyload(el, load_twikoo, <%= theme.comments.lazyload %>);
+  util.viewportLazyload(el, load_twikoo, <%= theme.comments.lazyload ?? false %>);
 
   function load_twikoo() {
     if (!el) return;

--- a/layout/_partial/comments/twikoo/script.ejs
+++ b/layout/_partial/comments/twikoo/script.ejs
@@ -1,20 +1,18 @@
-<script>
-    function load_twikoo() {
-        if (!document.querySelectorAll("#twikoo_container")[0]) return;
-        utils.js('<%- theme.comments.twikoo.js %>', {defer: true}).then(function () {
-            const el = document.getElementById("twikoo_container");
-            var path = el.getAttribute('comment_id');
-            if (!path) {
-                path = decodeURI(window.location.pathname);
-            }
-            twikoo.init(Object.assign(<%- JSON.stringify(theme.comments.twikoo) %>, {
-                el: '#twikoo_container',
-                path: path,
-            }));
-        });
-    }
+<script type="module">
+  const el = document.getElementById('artalk_container');
+  util.viewportLazyload(el, load_twikoo, <%= theme.comments.viewportLazyload %>);
 
-    window.addEventListener('DOMContentLoaded', (event) => {
-        load_twikoo();
+  function load_twikoo() {
+    if (!el) return;
+    utils.js('<%- theme.comments.twikoo.js %>', {defer: true}).then(function () {
+      const path = el.getAttribute('comment_id');
+      if (!path) {
+        path = decodeURI(window.location.pathname);
+      }
+      twikoo.init(Object.assign(<%- JSON.stringify(theme.comments.twikoo) %>, {
+        el: '#twikoo_container',
+        path: path,
+      }));
     });
+  }
 </script>

--- a/layout/_partial/comments/utterances/script.ejs
+++ b/layout/_partial/comments/utterances/script.ejs
@@ -1,26 +1,22 @@
-<script>
-  function loadUtterances() {
-    const els = document.querySelectorAll("#comments #utterances");
-    if (els.length === 0) return;
-    els.forEach((el, i) => {
-      try {
-        el.innerHTML = '';
-      } catch (error) {
-        console.error(error);
+<script type="module">
+  const el = document.querySelector("#comments #utterances");
+  util.viewportLazyload(el, load_utterances, <%= theme.comments.viewportLazyload %>);
+
+  function load_utterances() {
+    try {
+      el.innerHTML = '';
+    } catch (error) {
+      console.error(error);
+    }
+    const script = document.createElement('script');
+    script.src = 'https://utteranc.es/client.js';
+    script.async = true;
+    for (const key of Object.keys(el.attributes)) {
+      const attr = el.attributes[key];
+      if (['class', 'id'].includes(attr.name) === false) {
+        script.setAttribute(attr.name, attr.value);
       }
-      var script = document.createElement('script');
-      script.src = 'https://utteranc.es/client.js';
-      script.async = true;
-      for (let key of Object.keys(el.attributes)) {
-        let attr = el.attributes[key];
-        if (['class', 'id'].includes(attr.name) === false) {
-          script.setAttribute(attr.name, attr.value);
-        }
-      }
-      el.appendChild(script);
-    });
+    }
+    el.appendChild(script);
   }
-  window.addEventListener('DOMContentLoaded', (event) => {
-      loadUtterances();
-  });
 </script>

--- a/layout/_partial/comments/utterances/script.ejs
+++ b/layout/_partial/comments/utterances/script.ejs
@@ -1,6 +1,6 @@
 <script type="module">
   const el = document.querySelector("#comments #utterances");
-  util.viewportLazyload(el, load_utterances, <%= theme.comments.lazyload %>);
+  util.viewportLazyload(el, load_utterances, <%= theme.comments.lazyload ?? false %>);
 
   function load_utterances() {
     try {

--- a/layout/_partial/comments/utterances/script.ejs
+++ b/layout/_partial/comments/utterances/script.ejs
@@ -1,6 +1,6 @@
 <script type="module">
   const el = document.querySelector("#comments #utterances");
-  util.viewportLazyload(el, load_utterances, <%= theme.comments.viewportLazyload %>);
+  util.viewportLazyload(el, load_utterances, <%= theme.comments.lazyload %>);
 
   function load_utterances() {
     try {

--- a/layout/_partial/comments/utterances/script.ejs
+++ b/layout/_partial/comments/utterances/script.ejs
@@ -3,6 +3,7 @@
   util.viewportLazyload(el, load_utterances, <%= theme.comments.lazyload ?? false %>);
 
   function load_utterances() {
+    if (!el) return;
     try {
       el.innerHTML = '';
     } catch (error) {

--- a/layout/_partial/comments/waline/script.ejs
+++ b/layout/_partial/comments/waline/script.ejs
@@ -1,14 +1,16 @@
 <script type="module">
-  import { init } from '<%- theme.comments.waline.js %>'
+  import { init } from '<%- theme.comments.waline.js %>';
 
-  function load_comment(){
-    if(!document.getElementById("waline_container"))return;
+  const el = document.getElementById('waline_container');
+  util.viewportLazyload(el, load_waline, <%= theme.comments.viewportLazyload %>);
+
+  function load_waline(){
+    if (!el) return;
 
     utils.css('<%- theme.comments.waline.css %>');
     utils.css('<%- theme.comments.waline.meta_css %>');
 
-    const el = document.getElementById("waline_container");
-    var path = el.getAttribute('comment_id');
+    const path = el.getAttribute('comment_id');
     if (!path) {
       path = decodeURI(window.location.pathname);
     }
@@ -18,12 +20,12 @@
       path: path,
       <% if(!!theme.comments.waline.imageUploader?.api){ %>
         imageUploader: function(file) {
-          let headers = new Headers();
+          const headers = new Headers();
           headers.set('Accept', 'application/json');
           <% if(!!theme.comments.waline.imageUploader?.token) { %>
             headers.set('<%= theme.comments.waline.imageUploader?.tokenName %>', '<%= theme.comments.waline.imageUploader?.token %>')
           <% } %>
-          let formData = new FormData();
+          const formData = new FormData();
           formData.append('<%= theme.comments.waline.imageUploader?.fileName %>', file);
           return fetch('<%= theme.comments.waline.imageUploader?.api %>',{
             method: 'POST',
@@ -34,10 +36,5 @@
         },
       <% } %>
     }));
-
   }
-  window.addEventListener('DOMContentLoaded', (event) => {
-    load_comment();
-  });
-
 </script>

--- a/layout/_partial/comments/waline/script.ejs
+++ b/layout/_partial/comments/waline/script.ejs
@@ -2,7 +2,7 @@
   import { init } from '<%- theme.comments.waline.js %>';
 
   const el = document.getElementById('waline_container');
-  util.viewportLazyload(el, load_waline, <%= theme.comments.viewportLazyload %>);
+  util.viewportLazyload(el, load_waline, <%= theme.comments.lazyload %>);
 
   function load_waline(){
     if (!el) return;

--- a/layout/_partial/comments/waline/script.ejs
+++ b/layout/_partial/comments/waline/script.ejs
@@ -2,7 +2,7 @@
   import { init } from '<%- theme.comments.waline.js %>';
 
   const el = document.getElementById('waline_container');
-  util.viewportLazyload(el, load_waline, <%= theme.comments.lazyload %>);
+  util.viewportLazyload(el, load_waline, <%= theme.comments.lazyload ?? false %>);
 
   function load_waline(){
     if (!el) return;

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -58,6 +58,20 @@ const util = {
   scrollComment: () => {
     document.getElementById('comments').scrollIntoView({behavior: "smooth"});
   },
+
+  viewportLazyload: (target, func, enabled = true) => {
+    if (!enabled || !("IntersectionObserver" in window)) {
+      func();
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].intersectionRatio > 0) {
+        func();
+        observer.disconnect();
+      }
+    });
+    observer.observe(target);
+  }
 }
 
 const hud = {


### PR DESCRIPTION
支持评论区进入视口后懒加载，通过 ``theme.comments.lazyload`` 控制，默认关闭，向下兼容。

## 一些代码风格上的建议

``querySelectorAll`` 查询复数 ``id``，存在 ``id`` 重复的元素本身并不合理。

``DOMContentLoaded`` 事件可以使用 ``type="module"`` 的 ``<script>`` 取代，并且后者不会泄露任何作用域变量至全局。

``var`` 和 ``let`` 混用的问题，不变的常量用 ``const`` 定义是最好的，有内存优化。