### PR TITLE
[fix] multi renderer support, resolve #476

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -527,11 +527,9 @@ plugins:
   # https://github.com/KaTeX/KaTeX
   # 使用 hexo-renderer-markdown-it-plus 作为公式渲染器：npm uninstall hexo-renderer-marked --save npm install hexo-renderer-markdown-it-plus --save
   katex:
-    enable: #true # 可以在特定文章的 front-matter 中设置 katex: true 来开启，也可以在这里设置全局开启
+    enable: #true # hexo-renderer-markdown-it-plus 默认开启 katex，此选项仅用于引入样式
     inject: |
       <link rel="stylesheet" href="https://gcore.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css" integrity="sha384-vKruj+a13U8yHIkAyGgK1J3ArTLzrFGBbBc0tDp4ad/EyewESeXE/Iv67Aj8gKZ0" crossorigin="anonymous">
-      <script defer src="https://gcore.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.js" integrity="sha384-PwRUT/YqbnEjkZO0zZxNqcxACrXe+j766U2amXcgMg5457rve2Y7I6ZJSm2A0mS4" crossorigin="anonymous"></script>
-      <script defer src="https://gcore.jsdelivr.net/npm/katex@0.16.4/dist/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"onload="renderMathInElement(document.body);"></script>
   
   # MathJax
   # 需在Markdown文件开头加入mathjax: true

--- a/scripts/tags/lib/quot.js
+++ b/scripts/tags/lib/quot.js
@@ -9,7 +9,7 @@
 
 'use strict'
 
-module.exports = ctx => function(args) {
+module.exports = ctx => function (args) {
   var el = ''
   args = ctx.args.map(args, ['el', 'icon', 'prefix', 'suffix'], ['text'])
   if (!args.el) {
@@ -43,7 +43,6 @@ module.exports = ctx => function(args) {
   if (args.el.includes('h')) {
     el += '<div' + ' class="tag-plugin quot">'
     el += '<' + args.el + ' class="content" id="' + args.text + '"' + type + '>'
-    el += '<a href="#' + args.text + '" class="headerlink" title="' + args.text + '"></a>'
     el += content()
     el += '</' + args.el + '>'
     el += '</div>'

--- a/source/css/_components/md.styl
+++ b/source/css/_components/md.styl
@@ -30,7 +30,7 @@
     margin-left: 0.5em
   h1,h2,h3,h4,h5,h6
     text-align: center
-    a.headerlink
+    >a:first-child
       display: none
   h2
     margin: 2em 0 1.5em
@@ -71,29 +71,29 @@
   h1,h2,h3,h4,h5,h6
     color: var(--text)
     line-height: 1.8
+    >a:first-child
+      background: $color-theme
+      border-radius: 2px
+      margin-right: 8px
+      trans1 background
+      &:hover
+        background: $color-hover
+      &:before
+        content: ''
+        color: white
+        font-weight: 700
+        padding: 0 2px
+        font-size: $fs-12
+  h2
+    font-weight: 500
+    >a:first-child:before
+      content: ':'
+    
   blockquote, .tag-plugin
     h2,h3,h4,h5,h6
       margin-top: 0.25em
       margin-bottom: 0.25em
       
-  a.headerlink 
-    background: $color-theme
-    border-radius: 2px
-    margin-right: 8px
-    trans1 background
-  a.headerlink:hover
-    background: $color-hover
-  a.headerlink:before
-    content: ''
-    color: white
-    font-weight: 700
-    padding: 0 2px
-    font-size: $fs-12
-  h2
-    font-weight: 500
-    a.headerlink:before
-      content: ':'
-  
 .md-text.content:first-child .tag-plugin:first-child
   margin-top: 0
 

--- a/source/css/_components/tag-plugins/quot.styl
+++ b/source/css/_components/tag-plugins/quot.styl
@@ -11,8 +11,6 @@
     border-bottom: none
     font-weight: 700
     padding: 0 24px
-    a.headerlink
-      display: none
     @media screen and (max-width: $device-mobile)
       padding: 0 20px
     line-height: 1.2


### PR DESCRIPTION
`hexo-renderer-marked` 和 `hexo-renderer-markdown-it-plus` 为标题添加的锚点按钮的类名不一致，主题只对应 Hexo 默认渲染器做了适配。

通过更改 CSS 选择器，可以使多个渲染器生成的页面具有相同的标题样式，解决 #476 的问题。

同时，移除了 `{% quot %}` 标签中未使用的锚点按钮，进一步精简了代码，便于后期维护。