### PR TITLE
[fix] related_posts title

### DIFF
--- a/layout/_partial/main/article/related_posts.ejs
+++ b/layout/_partial/main/article/related_posts.ejs
@@ -4,7 +4,7 @@ function layoutDiv() {
     var el = '';
     el += `<div class="related-wrap${scrollreveal(' ')}" id="related-posts">`
     el += popular_posts_wrapper({
-      title: __('meta.related_posts'),
+      title: theme.article.related_posts.title || __('meta.related_posts'),
       json: popular_posts_json({ maxCount: theme.article.related_posts.max_count , ulClass: 'related-posts' , PPMixingRate: 0.2 , isImage: true , isExcerpt: true} , page )
     });
     el += '</div>';


### PR DESCRIPTION
解决 `theme.article.related_posts.title` 配置项无效的问题。