### PR TITLE
[fix] tianli_gpt layout

### DIFF
--- a/layout/_plugins/tianli_gpt.ejs
+++ b/layout/_plugins/tianli_gpt.ejs
@@ -1,6 +1,6 @@
 <% 
 const { field } = theme.plugins.tianli_gpt;
-const matchesField = field === 'all' || field === layout || (field === 'wiki' && page.wiki) || (field === 'topic' && page.topic);
+const matchesField = field === 'all' || field === page.layout || (field === 'wiki' && page.wiki) || (field === 'topic' && page.topic);
 if (matchesField) { %>
   <script defer src="<%- theme.plugins.tianli_gpt?.js %>"></script>
   <script defer>


### PR DESCRIPTION
我看代码的意思应该是当配置中配置的范围与该页面类型相同时启用，但原来的`layout`无法获取的页面类型，使得除非配置为`all`都用不了ai，要改成`page.layout`
![image](https://github.com/xaoxuu/hexo-theme-stellar/assets/63234268/6424d225-becc-4d3e-9695-b262879a7530)
![image](https://github.com/xaoxuu/hexo-theme-stellar/assets/63234268/46905492-acba-4540-b3f4-c9f0c36298f1)
