### PR TITLE
[fix] video tag

### DIFF
--- a/scripts/tags/lib/video.js
+++ b/scripts/tags/lib/video.js
@@ -8,14 +8,13 @@
 
 'use strict';
 
-module.exports = ctx => function(args) {
+module.exports = ctx => function (args) {
   args = ctx.args.map(args, ['type', 'bilibili', 'ratio', 'width', 'autoplay'], ['src'])
   if (args.width == null) {
     args.width = '100%'
   }
   if (args.bilibili) {
-    return `
-    <div class="tag-plugin video" style="aspect-ratio:${args.ratio || 16/9};max-width:${args.width};">
+    return `<div class="tag-plugin video" style="aspect-ratio:${args.ratio || 16 / 9};max-width:${args.width};">
     <iframe src="https://player.bilibili.com/player.html?bvid=${args.bilibili}&autoplay=${args.autoplay || 'false'}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true">
     </iframe>
     </div>

--- a/source/css/_components/tag-plugins/media.styl
+++ b/source/css/_components/tag-plugins/media.styl
@@ -1,6 +1,6 @@
 .tag-plugin.video
   line-height: 0
-  text-align: center
+  margin: auto
   video, iframe
     border-radius: $border-card
     box-shadow: $boxshadow-card-float


### PR DESCRIPTION
- 修复了设置宽度后视频不居中的问题
- 修复了bilibili视频无法放入grid标签的问题

建议官方文档中补充video标签的ratio、type参数的说明。