### PR TITLE
fix: link path in nav_tabs_blog.ejs

### DIFF
--- a/layout/_partial/main/navbar/nav_tabs_blog.ejs
+++ b/layout/_partial/main/navbar/nav_tabs_blog.ejs
@@ -11,37 +11,37 @@ function layoutDiv() {
 
   if (site.categories && site.categories.length > 0) {
     if (page.category) {
-      el += '<a class="active" href="' + url_for(config.category_dir) + '">' + __("btn.category") + __("symbol.colon") + page.category + '</a>';
+      el += '<a class="active" href="' + url_for(config.category_dir) + '/">' + __("btn.category") + __("symbol.colon") + page.category + '</a>';
     } else if (page.layout == "categories") {
-      el += '<a class="active" href="' + url_for(config.category_dir) + '">' + __("btn.categories") + '</a>';
+      el += '<a class="active" href="' + url_for(config.category_dir) + '/">' + __("btn.categories") + '</a>';
     } else {
-      el += '<a href="' + url_for(config.category_dir) + '">' + __("btn.categories") + '</a>';
+      el += '<a href="' + url_for(config.category_dir) + '/">' + __("btn.categories") + '</a>';
     }
   }
 
   if (site.tags && site.tags.length > 0) {
     if (page.tag) {
-      el += '<a class="active" href="' + url_for(config.tag_dir) + '">' + __("btn.tag") + __("symbol.colon") + page.tag + '</a>';
+      el += '<a class="active" href="' + url_for(config.tag_dir) + '/">' + __("btn.tag") + __("symbol.colon") + page.tag + '</a>';
     } else if (page.layout == "tags") {
-      el += '<a class="active" href="' + url_for(config.tag_dir) + '">' + __("btn.tags") + '</a>';
+      el += '<a class="active" href="' + url_for(config.tag_dir) + '/">' + __("btn.tags") + '</a>';
     } else {
-      el += '<a href="' + url_for(config.tag_dir) + '">' + __("btn.tags") + '</a>';
+      el += '<a href="' + url_for(config.tag_dir) + '/">' + __("btn.tags") + '</a>';
     }
   }
   
   if (theme.topic?.publish_list?.length > 0) {
     if (page.layout == 'index_topic') {
-      el += '<a class="active" href="' + url_for(theme.site_tree.index_topic.base_dir) + '">' + __("btn.topic") + '</a>';
+      el += '<a class="active" href="' + url_for(theme.site_tree.index_topic.base_dir) + '/">' + __("btn.topic") + '</a>';
     } else {
-      el += '<a href="' + url_for(theme.site_tree.index_topic.base_dir) + '">' + __("btn.topic") + '</a>';
+      el += '<a href="' + url_for(theme.site_tree.index_topic.base_dir) + '/">' + __("btn.topic") + '</a>';
     }
   }
   
   if (site.posts && site.posts.length > 0) {
     if (is_archive()) {
-      el += '<a class="active" href="' + url_for(config.archive_dir) + '">' + __("btn.archives") + '</a>';
+      el += '<a class="active" href="' + url_for(config.archive_dir) + '/">' + __("btn.archives") + '</a>';
     } else {
-      el += '<a href="' + url_for(config.archive_dir) + '">' + __("btn.archives") + '</a>';
+      el += '<a href="' + url_for(config.archive_dir) + '/">' + __("btn.archives") + '</a>';
     }
   }
   


### PR DESCRIPTION
群友在 nginx 服务器上部署遇到问题，首页导航栏的“标签”“分类”等按钮链接应当尾随斜杠，否则默认配置下无法访问。

另外，也可添加以下 nginx 配置解决问题。

```nginx
    index index.html;
    location / {
        try_files $uri $uri.html $uri/ =404;
    }
    error_page 404 /404.html;
```