### PR TITLE
fix: youtube iframe

### DIFF
--- a/scripts/tags/lib/video.js
+++ b/scripts/tags/lib/video.js
@@ -21,8 +21,13 @@ module.exports = ctx => function (args) {
     `
   }
   if (args.youtube) {
-    return `<div class="tag-plugin video" style="aspect-ratio:${args.ratio || 16/9};max-width:${args.width};">
-    <iframe src="https://www.youtube.com/embed/${args.youtube}?rel=0&color=white&disablekb=1&playsinline=1&&rel=0&autoplay=${args.autoplay || '0'}" picture-in-picture="true" allowfullscreen="true" >
+    if(args.autoplay == 'true' || args.autoplay == '1') { 
+      args.autoplay = '1&mute=1'
+    } else {
+      args.autoplay = '0'
+    }
+    return `<div class="tag-plugin video" style="aspect-ratio:${args.ratio || 16 / 9};max-width:${args.width};">
+    <iframe style="border:none" src="https://www.youtube.com/embed/${args.youtube}?rel=0&disablekb=1&playsinline=1&autoplay=${args.autoplay}" picture-in-picture="true" allowfullscreen="true" >
     </iframe>
     </div>
     `


### PR DESCRIPTION
共有两处修改：
1. 对 `iframe` 添加了 `border:none` 干掉了垃圾 iframe 自带的一层白边，还挺影响深色模式的观感的。
去除前：
![image](https://github.com/user-attachments/assets/c5fc9c5f-3df5-4739-8587-be2a3841261f)
2. 根据 [Chrome 的老旧政策](https://stackoverflow.com/questions/40685142/youtube-autoplay-does-not-work-with-iframe) ，自动开播需要追加 `mute=1` 以静音。