### PR TITLE
fix: h2 font-weight Inconsistent

### DIFF
--- a/source/css/_components/md.styl
+++ b/source/css/_components/md.styl
@@ -85,7 +85,6 @@
         padding: 0 2px
         font-size: $fs-12
   h2
-    font-weight: 500
     >a:first-child:before
       content: ':'
     


### PR DESCRIPTION
- H2标题的font-weight与其他层级标题存在较为明显的不一致性，故去掉额外设置的font-weight: 500样式
![image](https://github.com/user-attachments/assets/6856a312-817c-464a-a199-4dc0b9e89808)