### PR TITLE
[fix] notebooks undefined

### DIFF
--- a/scripts/generators/notebooks.js
+++ b/scripts/generators/notebooks.js
@@ -30,7 +30,7 @@ function paginationWithEmpty(base, posts, options={}) {
 
 hexo.extend.generator.register('notebooks', function (locals) {
   const { site_tree, notebooks } = hexo.theme.config
-  if (notebooks.tree.length === 0) {
+  if (notebooks.tree.length === undefined) {
     return []
   }
 


### PR DESCRIPTION
notebooks不设置时生成额外的空 `notebooks/` 页面 #507 