### PR TITLE
[fix]: 修复hexo路由改变造成无法正常加载theme资源文件的bug

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -119,7 +119,8 @@ function custom_inject() {
     <%- feed_tag(config.feed.path, {title: config.title}) %>
   <% } %>
 
-  <link rel="stylesheet" href="<%- `${theme.stellar.main_css}?v=${stellar_info('version')}` %>">
+  <link rel="stylesheet" href="<%- url_for(`${theme.stellar.main_css}?v=${stellar_info('version')}`) %>">
+
 
   <% if (config.favicon) { %>
     <%- favicon_tag(config.favicon) %>

--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -21,7 +21,7 @@ function custom_inject() {
 <%- partial('scripts/tagtree') %>
 
 <!-- required -->
-<script src="<%- `${theme.stellar.main_js}?v=${stellar_info('version')}` %>" defer></script>
+<script src="<%- url_for(`${theme.stellar.main_js}?v=${stellar_info('version')}`) %>" defer></script>
 
 <%- partial('scripts/theme') %>
 


### PR DESCRIPTION
由于在hexo的_config文件中定义url的root选项，造成theme无法加载theme中css,js资源文件的bug
通过在head.ejs与script.ejs文件的包括语句增加url_for函数解决