### PR TITLE
[fix] tabs mermaid syntax error

### DIFF
--- a/source/css/_components/tag-plugins/tabs.styl
+++ b/source/css/_components/tag-plugins/tabs.styl
@@ -76,10 +76,13 @@
     text-align: justify
     margin-top: .5rem
     .tab-pane
+      display: block
       &:not(.active)
-        display: none
+        visibility: hidden
+        height: 0
       &.active
-        display: block
+        visibility: visible
+        height: auto
   .tab-content:has(.grid-box)
     width: 100%
 


### PR DESCRIPTION
fix: #308 

除开tabs标签，其他的容器类标签（folding folder等）在嵌套mermaid的时候有可能会导致语法错误，例如

{% folding mermaid示例 %}
```mermaid
graph LR
  A --> B
  B --> C
  C --> D
```
{% endfolding %}

由于部分mermaid图表依赖换行符与缩进来解析不同的命令和结构，而 `.split('\n').join('')` 删除了所有的换行符，Mermaid 的解析器将无法正确地理解上述代码，因为它会被压缩成一行

```
graph LRA --> BB --> CC --> D
```