### PR TITLE
fix: 页面没有使用tags生成keywords，文章搜索没有生成tags和categories

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -37,7 +37,7 @@ function generate_description() {
 function generate_keywords() {
   if (page.keywords && page.keywords.length > 0) {
     return '<meta name="keywords" content="' + page.keywords + '">';
-  } else if (page.tags && Array.isArray(page.tags) && page.tags.length > 0) {
+  } else if (page.tags && page.tags.length > 0) {
     return '<meta name="keywords" content="' + page.tags.map(tag => tag.name).join(',') + '">';
   } else if (config.keywords && config.keywords.length > 0) {
     return '<meta name="keywords" content="' + config.keywords + '">';

--- a/scripts/generators/search.js
+++ b/scripts/generators/search.js
@@ -43,14 +43,14 @@ hexo.extend.generator.register('search_json_generator', function (locals) {
       content = content.replace(/[\s]{2,}/g, ' ')
       temp_post.content = content.trim()
     }
-    if (post.tags && Array.isArray(post.tags) && post.tags.length > 0) {
+    if (post.tags && post.tags.length > 0) {
       var tags = []
       post.tags.forEach(function (tag) {
         tags.push(tag.name)
       })
       temp_post.tags = tags
     }
-    if (post.categories && Array.isArray(post.categories) && post.categories.length > 0) {
+    if (post.categories && post.categories.length > 0) {
       var categories = []
       post.categories.forEach(function (cate) {
         categories.push(cate.name)


### PR DESCRIPTION
使用了错误的条件，Array.isArray(page.tags)、Array.isArray(post.tags)、Array.isArray(post.categories)一直是false

![head.js](https://github.com/user-attachments/assets/96cc069c-9bde-4ed1-a1dc-70c4ed090c15)
![search.js](https://github.com/user-attachments/assets/9c5031de-4b1a-4560-b186-8e76788f5877)
![search.js](https://github.com/user-attachments/assets/3c52fa12-3a76-438e-8e41-263e7733521c)
