### PR TITLE
fix(notebooks): fix bug in notebooks generator

### DIFF
--- a/scripts/generators/notebooks.js
+++ b/scripts/generators/notebooks.js
@@ -30,7 +30,7 @@ function paginationWithEmpty(base, posts, options={}) {
 
 hexo.extend.generator.register('notebooks', function (locals) {
   const { site_tree, notebooks } = hexo.theme.config
-  if (notebooks.tree.length === undefined) {
+  if (!notebooks?.tree || Object.keys(notebooks.tree).length === 0) {
     return []
   }
 


### PR DESCRIPTION
`notebooks.tree` is an object, not array.

修复在 notebooks generator 中，之前对 `notebooks.tree` 是否为空的错误判定。

最初版本 `notebooks.tree.length === 0` 会导致没有 notebook 的时候，拦不住。

后一个版本 `notebooks.tree.length === undefined` 会导致有 notebooks 的时候也直接返回。

因为 `notebooks.tree` 是对象而不是数组，取 `length` 始终返回 `undefined`。
