### PR TITLE
fix: refine katex overflow style

### DIFF
--- a/source/css/_plugins/katex.styl
+++ b/source/css/_plugins/katex.styl
@@ -1,5 +1,4 @@
 .md-text 
   p.katex-block
-  .katex-display
     overflow: scroll
     scrollbar(0, 0)


### PR DESCRIPTION
之前 katex 的 `overflow` 样式是设置在 `.md-text p.katex-block .katex-display` 上的，在有些时候会出现当鼠标在公式那里上下滚动的时候，公式会上下微小浮动，如图：

![katex-overflow](https://github.com/user-attachments/assets/776d4003-d8da-4d87-b0fb-1c5f4b0c6502)

把 `overflow` 改在 `.md-text p.katex-block` 上没有这个问题。
