### PR TITLE
[fix] 修复folding标签渲染异常问题

### DIFF
--- a/scripts/tags/lib/folding.js
+++ b/scripts/tags/lib/folding.js
@@ -23,7 +23,7 @@ module.exports = ctx => function(args, content) {
   el += '<summary>' + ctx.render.renderSync({text: (args.title || ''), engine: 'markdown'}) + '</summary>'
   // content
   el += '<div class="body">'
-  el += ctx.render.renderSync({text: content, engine: 'markdown'}).split('\n').join('')
+  el += ctx.render.renderSync({text: content, engine: 'markdown'}).split('\n').join(' ')
   el += '</div></details>'
 
   return el


### PR DESCRIPTION
`ctx.render.renderSync({text: content, engine: 'markdown'})`对图片的渲染结果为：

```html
<img
src="https://example.com/a.png"
alt="description" />
```

将`\n`替换为空字符导致其变为
```html
<imgsrc="https://example.com/a.png"alt="description" />
```

经过处理lazyload的filter又会变为
```html
<img class=""src="data:image/png;base64,......" data-src="https://example.com/a.png"alt="description lazy" />
```

**将`\n`替换为空格可解决问题**

另外，Windows系统下未出现过此问题，但Github Action和我的Fedora都出现此问题，原因未知，可能和不同系统换行符差异有关