### PR TITLE
[fix] 修复mermaid暗色配置项的一个小问题

### DIFF
--- a/layout/_plugins/mermaid.ejs
+++ b/layout/_plugins/mermaid.ejs
@@ -4,7 +4,7 @@
     var mermaid_config = {
       startOnLoad: true,
       theme:
-        "<%- theme.style.darkmode %>" == "auto" &&
+        "<%- theme.style.prefers_theme %>" == "auto" &&
           window.matchMedia("(prefers-color-scheme: dark)").matches
           ? "dark"
           : "<%- conf.theme %>",


### PR DESCRIPTION
在暗色模式下，Mermaid 图表未能自动切换为 `dark` 主题，仍然使用浅色，导致显示异常。

经查是模板中 EJS (themes/stellar/layout/_plugins/mermaid.ejs) 判断用的是：

```js
"<%- theme.style.darkmode %>" == "auto" && ...
```

但实际配置项是：

```yaml
style:
  prefers_theme: auto
```

修改为了：

```js
"<%- theme.style.prefers_theme %>" == "auto" && ...
```