### PR TITLE
[feat] Add canonical tags for SEO multi-copy optimization

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -93,6 +93,7 @@ function custom_inject() {
 <head>
   <meta charset="utf-8">
   <meta name="hexo-theme" content="<%- stellar_info('tree') %>" theme-name="<%- stellar_info('name') %>" theme-version="<%- stellar_info('version') %>">
+  <link rel="canonical" href="<%= page.__index ? config.url : (page.permalink || page.path) %>" />
   <%- generate_robots() %>
   <%- meta_generator() %>
   <meta http-equiv='x-dns-prefetch-control' content='on' />


### PR DESCRIPTION
Specify a canonical URL engine for duplicate or very similar pages to search, reducing the impact of multiple copies on SEO. 
[canonical](https://developers.google.cn/search/docs/crawling-indexing/consolidate-duplicate-urls?hl=zh-cn)