### PR TITLE
[fix]pretty_urls.js

### DIFF
--- a/scripts/filters/pretty_urls.js
+++ b/scripts/filters/pretty_urls.js
@@ -14,7 +14,7 @@ hexo.extend.generator.register('page', function (locals) {
       typeof page.layout === 'undefined'
     ) ? false : page.layout;
 
-    const isRawOutput = /\.(txt|json|xml)$/.test(path);
+    const isRawOutput = /\.(txt|json|xml|js|css)$/.test(path);
 
     return {
       path,


### PR DESCRIPTION
现有的原始内容输出列表没包括js，css，会导致用户在source目录中存放的js，css被错误处理成json形式

![Snipaste_2025-07-05_12-42-26](https://github.com/user-attachments/assets/4d359ef8-83e1-4713-b3ca-8fdd333ae705)


