### PR TITLE
[feat] 增加 mathjax v3 的支援

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -594,8 +594,9 @@ plugins:
   # 需在Markdown文件开头加入mathjax: true
   # 推荐使用Pandoc: npm uninstall hexo-renderer-marked --save & npm install hexo-renderer-pandoc --save
   mathjax:
+    v3: false # 若使用 v3，需將 js 設置為 https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js
     enable: # true # 可以在特定文章的 front-matter 中设置 mathjax: true 来开启，也可以在这里设置全局开启
-    js: https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js
+    js: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 
   # Mermaid - markdwon to flow chart, seq chart, class chart ...
   # 需要安装 npm install --save hexo-filter-mermaid-diagrams

--- a/_config.yml
+++ b/_config.yml
@@ -595,7 +595,7 @@ plugins:
   # 推荐使用Pandoc: npm uninstall hexo-renderer-marked --save & npm install hexo-renderer-pandoc --save
   mathjax:
     enable: # true # 可以在特定文章的 front-matter 中设置 mathjax: true 来开启，也可以在这里设置全局开启
-    js: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+    js: https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js
 
   # Mermaid - markdwon to flow chart, seq chart, class chart ...
   # 需要安装 npm install --save hexo-filter-mermaid-diagrams

--- a/layout/_plugins/mathjax.ejs
+++ b/layout/_plugins/mathjax.ejs
@@ -1,20 +1,26 @@
-<script type="text/javascript" src="<%- conf.js %>"></script>
-<script type="text/x-mathjax-config">
-MathJax.Hub.Config({
-  tex2jax: {
-    inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-    processEscapes: true
-  }
-});
-MathJax.Hub.Config({
-  tex2jax: {
-    skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
-  }
-});
-MathJax.Hub.Queue(function() {
-  var all = MathJax.Hub.getAllJax(), i;
-  for(i=0; i < all.length; i += 1) {
-    all[i].SourceElement().parentNode.className += ' has-jax';
-  }
-});
+<script>
+  window.MathJax = {
+    tex: {
+      inlineMath: [
+        ["$", "$"],
+        ["\\(", "\\)"],
+      ],
+      processEscapes: true,
+      skipTags: ["script", "noscript", "style", "textarea", "pre", "code"],
+    },
+    startup: {
+      ready() {
+        MathJax.startup.defaultReady();
+        MathJax.typesetPromise().then(() => {
+          const math = document.querySelectorAll("mjx-container");
+          math.forEach((element) => {
+            if (element.parentNode) {
+              element.parentNode.classList.add("has-jax");
+            }
+          });
+        });
+      },
+    },
+  };
 </script>
+<script id="MathJax-script" src="<%- conf.js %>" async></script>

--- a/layout/_plugins/mathjax.ejs
+++ b/layout/_plugins/mathjax.ejs
@@ -1,3 +1,4 @@
+<% if (conf.v3) { %>
 <script>
   window.MathJax = {
     tex: {
@@ -23,4 +24,26 @@
     },
   };
 </script>
+<% } %>
 <script id="MathJax-script" src="<%- conf.js %>" async></script>
+<% if (!conf.v3) { %>
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    tex2jax: {
+      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+      processEscapes: true
+    }
+  });
+  MathJax.Hub.Config({
+    tex2jax: {
+      skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+    }
+  });
+  MathJax.Hub.Queue(function() {
+    var all = MathJax.Hub.getAllJax(), i;
+    for(i=0; i < all.length; i += 1) {
+      all[i].SourceElement().parentNode.className += ' has-jax';
+    }
+  });
+</script>
+<% } %>


### PR DESCRIPTION
## 升级 MathJax 支持 v3 版本

### 问题描述

在使用 MathJax v2 时遇到 Chrome 浏览器无法正确显示特定数学符号的问题。虽然可以通过修改 `plugins.mathjax.js` 配置来替换为 v3 版本的 CDN 链接，但由于 v2 和 v3 的配置语法完全不同，仅仅替换 CDN 链接无法正常工作，还需要同步更新相应的初始化脚本。

### 解决方案

本 PR 新增对 MathJax v3 的原生支持，通过以下方式解决上述问题：

#### 新增功能
- **新增配置选项** `plugins.mathjax.v3`：布尔值，控制使用 MathJax v2 或 v3 版本
- **自动版本切换**：根据 `v3` 配置自动选择对应的初始化脚本和 CDN 链接
- **配置对等性**：v3 版本的配置功能与 v2 版本完全对等，支持相同的数学公式渲染需求

#### 向后兼容性
- **默认行为不变**：未设置 `v3` 选项时，默认使用 v2 版本，保持原有行为
- **现有配置不受影响**：已配置 MathJax 的博客无需修改任何设置即可正常工作

#### 配置示例

```yaml
plugins:
  mathjax:
    enable: true
    v3: true  # 新增选项，设为 true 使用 v3 版本
    js: https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-mml-chtml.js # 启用 v3 时需指定 js
```
