### PR TITLE
add new-note command

### DIFF
--- a/scripts/commands/new-note.js
+++ b/scripts/commands/new-note.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const fs = require('fs');
+
+hexo.extend.console.register('new-note', 'Create a new note', {
+  options: [
+    { name: '-n, --name', desc: 'Note name', required: true },
+    { name: '-bk, --book', desc: 'Notebook name', required: true },
+    { name: '-tag, --tag', desc: 'Tags (comma separated)', required: false }
+  ]
+}, function(args, callback) {
+  const name = args.name || args.n;
+  const book = args.book || args.bk || args.k;
+  const tagStr = args.tag ||args.g ||'';
+  if (!name || !book) {
+    console.log('Usage: hexo new-note -n "name" -bk "notebook" -tag "tag1,tag2/subtag1"');
+    return callback();
+  }
+
+  const date = new Date();
+  const filename = `${name}.md`;
+  const notebookDir = path.join(hexo.source_dir, 'notebooks', book);
+  if (!fs.existsSync(notebookDir)) {
+    fs.mkdirSync(notebookDir, { recursive: true });
+  }
+  const filePath = path.join(notebookDir, filename);
+  if (fs.existsSync(filePath)) {
+    console.log(`File ${filename} already exists in ${notebookDir}.`);
+    return callback();
+  }
+  // 处理标签
+  let tags = [];
+  if (tagStr) {
+    tags = tagStr.split(',').map(t => t.trim()).filter(Boolean);
+  }
+  // 生成表头
+  const frontMatter = [
+    '---',
+    `title: ${name}`,
+    `date: ${date.getFullYear()}-${String(date.getMonth()+1).padStart(2,'0')}-${String(date.getDate()).padStart(2,'0')} ${String(date.getHours()).padStart(2,'0')}:${String(date.getMinutes()).padStart(2,'0')}:${String(date.getSeconds()).padStart(2,'0')}`,
+    `tags: [${tags.map(t => '"'+t+'"').join(', ')}]`,
+    `notebook: ${book}`,
+    '---',
+    '',
+    ''
+  ].join('\n');
+  fs.writeFileSync(filePath, frontMatter);
+  console.log(`Created: ${filePath}`);
+  callback();
+}); 


### PR DESCRIPTION
## Why need?

#PR #594 说明了快速创建笔记的这个功能的需求。

## What does this PR do?
新增了快速创建笔记的命令
会自动在对应文件夹下创建markdown文件，并设置`front-matter`中的相关信息

## Usage
```bash
Usage: hexo new-note -n "name" -bk "notebook" -tag "tag1,tag2/subtag1"
```

例如使用
```bash
hexo new-note -n test-title  -bk other -tag test-tag
```
在notebook other下创建名为 test-title 的note，并设置tag 为test-tag

<img width="1217" height="271" alt="image" src="https://github.com/user-attachments/assets/f2211c0b-8ae6-44f3-9d59-de1e7dee76ea" />


会自动在最合适的位置创建目录与md文件
<img width="537" height="314" alt="image" src="https://github.com/user-attachments/assets/f95db4ae-2be1-462e-a791-8176d20fe30b" />


同时合理设置`front-matter`
<img width="647" height="276" alt="image" src="https://github.com/user-attachments/assets/46575c80-320e-4473-b892-2354621f90d1" />



##TODO 
新增new-note供讨论，如果需要，可继续添加`new-wiki` 、`new-notebook`等命令 
