### PR TITLE
fix: ensure page uses fallback layout missing

### DIFF
--- a/scripts/filters/pretty_urls.js
+++ b/scripts/filters/pretty_urls.js
@@ -18,7 +18,7 @@ hexo.extend.generator.register('page', function (locals) {
 
     return {
       path,
-      layout,
+      layout: layout === 'page' ? ['page'] : [layout, 'page'],
       data: isRawOutput ? page.content : page
     };
   });


### PR DESCRIPTION
主题重写了默认的 page 生成器，且无 wiki.ejs，导致 wiki 页面渲染失败。增加模板查找 fallback 策略（page.ejs），临时兜底支持未定义 layout 的页面，避免渲染错误。后续佬看看怎么回事。