### PR TITLE
fix: chat.styl

### DIFF
--- a/source/css/_components/tag-plugins/chat.styl
+++ b/source/css/_components/tag-plugins/chat.styl
@@ -39,8 +39,6 @@ chat_dark()
         font-size: $fs-12
     .cap
         color: var(--text-p3)
-    *
-        word-break: break-all
     box-sizing: border-box
     -webkit-box-sizing: border-box
     -moz-box-sizing: border-box
@@ -62,7 +60,7 @@ chat_dark()
         position: relative
         box-shadow: unset
         >.device-image
-            background-image: url(https://gcore.jsdelivr.net/gh/cdn-x/placeholder@1.0.4/frame/iphone11.svg)
+            background-image: url(https://gcore.jsdelivr.net/gh/cdn-x/placeholder@1.0.14/frame/iphone11.svg)
             width: 100%
             height: 100%
             position: absolute


### PR DESCRIPTION
1. 去掉`word-break: break-all`防止英文语境下拆散单词
2. 修复设备背景图片链接错误