### PR TITLE
feat: support separate light/dark leftbar background colors when using solid color

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -671,7 +671,9 @@ style:
     start: 'linear-gradient(to right, hsl(215, 95%, 64%), hsl(195, 95%, 60%), hsl(165, 95%, 56%), hsl(165, 95%, 56%), hsl(195 95% 60%), hsl(215, 95%, 64%))'
   leftbar:
     # 可以设置：纯色/渐变色/图片作为背景
-    background-color: var(--card) # var(--block)
+    # 设置为纯色时，可以分别设置浅色和深色模式背景色
+    background-color-light: var(--card) # var(--block) #'rgb(#C3C3C3)'
+    background-color-dark: var(--card) # var(--block) #'rgb(#3C3C3C)'
     background-image: url(https://gcore.jsdelivr.net/gh/cdn-x/placeholder@1.0.13/image/sidebar-bg1@small.jpg)
     blur-px: 100px
     blur-bg: var(--bg-a60)

--- a/source/css/_components/sidebar/sidebar.styl
+++ b/source/css/_components/sidebar/sidebar.styl
@@ -40,9 +40,11 @@
       filter: saturate(var(--saturate)) blur(var(--blur-px)) opacity(var(--background-opacity))
       @media screen and (prefers-color-scheme: dark)
         --background-opacity: hexo-config('style.leftbar.background-opacity') * 0.75
-    else if $leftbar-background-color
-      background-color: convert($leftbar-background-color)
-    
+    else if $leftbar-background-color-light || $leftbar-background-color-dark
+      background-color: convert($leftbar-background-color-light)
+      @media screen and (prefers-color-scheme: dark)
+        background-color: convert($leftbar-background-color-dark)
+
   .leftbar-container
     height: 'calc(%s - %s * 2 - %s)' % (100vh var(--gap-margin) $leftbar-bottom-margin)
     display: flex

--- a/source/css/_custom.styl
+++ b/source/css/_custom.styl
@@ -31,7 +31,8 @@ $fsp3 = 'calc(%s - 3px)' % $fs-body
 // site main
 $site-background-image = hexo-config('style.site.background-image')
 $leftbar-background-image = hexo-config('style.leftbar.background-image')
-$leftbar-background-color = hexo-config('style.leftbar.background-color')
+$leftbar-background-color-light = hexo-config('style.leftbar.background-color-light')
+$leftbar-background-color-dark = hexo-config('style.leftbar.background-color-dark')
 
 
 // colors


### PR DESCRIPTION
将原配置项 `background-color` 拆分为 `background-color-light` 和 `background-color-dark`，左侧边栏背景色设置为纯色时，可以分别设置浅色模式和深色模式的背景颜色。同时设置为 `var(--card) ` 时，和原配置行为一致。

示例配置片段：
```
  leftbar:
    background-color-light:  'rgb(#C3C3C3)' 
    background-color-dark:  'rgb(#3C3C3C)' 
    # 设置纯色时，背景图片要留空，否则图片会覆盖纯色配置
    background-image: 
```