### PR TITLE
fix: resolve katex.min.css being blocked

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -587,8 +587,8 @@ plugins:
   katex:
     enable: #true # hexo-renderer-markdown-it-plus 默认开启 katex，此选项仅用于引入样式
     inject: |
-      <link rel="stylesheet" href="https://gcore.jsdelivr.net/npm/katex@0.16/dist/katex.min.css" integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP" crossorigin="anonymous">
-  
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.23/dist/katex.min.css" integrity="sha384-//SZkxyB7axjCAopkAL1E1rve+ZSPKapD89Lo/lLhcsXR+zOYl5z6zJZEFXil+q0" crossorigin="anonymous">
+
   # MathJax
   # 需在Markdown文件开头加入mathjax: true
   # 推荐使用Pandoc: npm uninstall hexo-renderer-marked --save & npm install hexo-renderer-pandoc --save


### PR DESCRIPTION
katex 小版本更新 katex@0.16.22 -> katex@0.16.23 integrity值发生变化，原链接中的 `katex@0.16` 总是指向最新版本。

将css导入链接固定为 `katex@0.16.23`，后续升级时替换包含适配对应版本integrity的整个链接。

