### PR TITLE
opt: canonical logic

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,8 @@ preconnect:
 # 一旦设置源站地址，非源站地址将不会被SEO收录，并且访问时弹出提示
 # 如果访问地址不在备用站主机列表，则警告信息为非法克隆
 canonical:
+  closeEnable: true # 是否显示关闭提示按钮
+  closeText: 关闭提示 # 关闭提示按钮的文字描述
   originalHost: # 主站点域名主机，例如 xaoxuu.com
   officialHosts: # 官方主机列表，每行一个，例如 xaoxuu.vercel.app
     - localhost

--- a/layout/_partial/scripts/defines.ejs
+++ b/layout/_partial/scripts/defines.ejs
@@ -4,10 +4,13 @@
   const canonicalWithEncoded = Object.assign({}, canonical, {
     encoded: encoded
   });
+  const permalink = page.permalink || canonical.originalHost;
+  const checklink = theme.data_services.video.js
 %>
 
 <script type="text/javascript">
   window.canonical = <%- JSON.stringify(canonicalWithEncoded) %>;
+  window.canonical["param"] = <%- JSON.stringify({permalink, checklink}) %>;
   const ctx = {
     date_suffix: {
       just: `<%- __('meta.date_suffix.just') %>`,

--- a/source/css/_common/canonical.styl
+++ b/source/css/_common/canonical.styl
@@ -1,23 +1,28 @@
 .canonical-tip
   position: fixed
+  display: flex
   text-align: center
   bottom: 4rem
   left: 50%
   transform: translateX(-50%)
   max-width: 90%
-  background-color: var(--card)
-  color: var(--text-p1)
-  font-size: 1rem
+  color: var(--text)
   font-family: #fff8e1
   z-index: 9999999
   box-shadow: 0 2px 8px rgba(black, .1), 0 4px 16px rgba(black, .1), 0 8px 32px rgba(black, .1)
-  border-radius: 6px
   .headline
     font-size: $fsh2
-  a
+  a, button
+    border-radius: 6px
+    background: var(--bg-a100)
     display: block
     color: inherit
-    padding: 1rem 2rem
+    padding: 1rem
+    font-size: 1rem
+  button
+    padding: 0
+    width: 3rem
+    margin-left: 1px
 
 .canonical-tip.unofficial
   background-color: hsl(5, 100%, 60%)


### PR DESCRIPTION
## 优化官方备用站（canonical）提示逻辑

**相关 Issue:** #623

本次提交主要优化官方备用站（canonical）的提示行为，提升用户体验与逻辑严谨性，具体包括：

### 修订点

1. **支持配置关闭提示按钮**
   - 新增配置项 `canonical.closeEnable`：控制是否显示“关闭提示”按钮
   - 新增配置项 `canonical.closeText`：自定义关闭按钮的文字（默认为「关闭提示」）

2. **用户关闭提示后当日不再重复显示**（通过 localStorage 记录）

3. **智能检测主站状态，避免无效提示**
   - 在备用站显示提示信息 **前**，会先通过脚本检测主站是否可访问（是否离线）
   - 如果主站离线或无法连接，则 **不显示备用站提示框**

4. **跳转主站时精准跳转至当前页面**
   - 点击提示中的“移步主站”链接时，会跳转到用户当前正在浏览的页面，而非固定首页

### 非法克隆站逻辑

- 对于非法克隆站（非官方授权的备用站），**除第 4 点（跳转逻辑）外，其它行为保持不变**
  - 即：仍会显示非法站点提示，且不会应用上述备用站的优化逻辑
  
### 测试用例
- 关闭按钮与跳转测试: https://hexo.thatcoder.cn/daily/jiaodong-peninsula/
- 离线监测已自测
