### PR TITLE
fix: 将 XML/RSS 文件加入 PJAX 黑名单 

### DIFF
--- a/source/js/plugins/pjax.js
+++ b/source/js/plugins/pjax.js
@@ -50,7 +50,7 @@
 
     // Skip links to non-HTML resources
     const ext = url.pathname.split('.').pop().toLowerCase();
-    const nonHtmlExts = ['pdf', 'zip', 'rar', 'exe', 'dmg', 'doc', 'xls', 'ppt', 'mp3', 'mp4', 'avi', 'mov'];
+    const nonHtmlExts = ['xml', 'rss', 'pdf', 'zip', 'rar', 'exe', 'dmg', 'doc', 'xls', 'ppt', 'mp3', 'mp4', 'avi', 'mov'];
     if (nonHtmlExts.includes(ext)) return false;
 
     return true;

--- a/source/js/plugins/pjax.js
+++ b/source/js/plugins/pjax.js
@@ -126,8 +126,30 @@
    * Replace content in the current page
    */
   function replaceContent(contents, selectors, doc) {
-    // 1. Update HTML attributes (theme, lang, etc.)
-    syncAttributes(doc.documentElement, document.documentElement);
+    // 1. Update HTML attributes (theme except data-theme, lang, etc.)
+    const newHtmlAttrs = contents._htmlAttrs;
+    if (newHtmlAttrs) {
+      // Remove data-theme from new attributes to prevent overwriting user's saved theme
+      const attrsToSync = { ...newHtmlAttrs };
+      delete attrsToSync['data-theme'];
+      
+      // Sync all attributes
+      Object.keys(attrsToSync).forEach(attrName => {
+        const newValue = attrsToSync[attrName];
+        const oldValue = document.documentElement.getAttribute(attrName);
+        if (newValue !== oldValue) {
+          document.documentElement.setAttribute(attrName, newValue);
+        }
+      });
+      
+      // Remove attributes that exist in current html but not in new html (except data-theme)
+      Array.from(document.documentElement.attributes).forEach(attr => {
+        if (attr.name !== 'data-theme' && !(attr.name in attrsToSync)) {
+          document.documentElement.removeAttribute(attr.name);
+        }
+      });
+    }
+    
     if (contents.title) document.title = contents.title;
     if (contents._bodyClasses) document.body.className = contents._bodyClasses;
 


### PR DESCRIPTION
- 在 nonHtmlExts 数组中添加 'xml'、'rss'，避免 PJAX 错误地将 XML 内容当作 HTML 处理
- 解决点击 atom.xml 内链时页面空白的问题