### PR TITLE
fix: 标签行负边距导致移动端页面横向溢出

### DIFF
--- a/source/css/_components/pages/archives.styl
+++ b/source/css/_components/pages/archives.styl
@@ -81,9 +81,12 @@
   display: flex
   flex-wrap: wrap
   padding: 0
-  margin: 0 -0.5rem
+  margin: 0
+  column-gap: 1rem
   a.tag
     tag-chip()
+    margin-left: 0
+    margin-right: 0
 
 @media screen and (min-width: $device-mobile)
   .post-list.author #archive

--- a/source/css/_components/partial/article-tags.styl
+++ b/source/css/_components/partial/article-tags.styl
@@ -4,7 +4,10 @@
   flex-wrap: wrap
   justify-content: center
   align-items: center
-  margin: 2rem -0.5rem 0
+  margin: 2rem 0 0
+  column-gap: 1rem
   line-height: 1.6
   a.tag
     tag-chip()
+    margin-left: 0
+    margin-right: 0


### PR DESCRIPTION
## 变更说明

对于标签，使用容器的`column-gap`保持间距，而不是让标签自己控制间距

以解决标签容器负边距横向溢出页面问题

<img width="539" height="270" alt="image" src="https://github.com/user-attachments/assets/936f4097-a880-43ce-88cc-f5c97c46d68e" />


## 改动范围

- [ ] `layout/`（EJS 模板）
- [ ] `scripts/`（Hexo 标签 / 辅助函数 / 过滤器）
- [x] `source/css/`（Stylus 样式）
- [ ] `source/js/`（浏览器脚本）
- [ ] `languages/`（国际化文案）
- [ ] `docs/`（方案 / 知识库 / 文档）

## 验证清单

- [ ] 涉及 `scripts/` 时已在主工程执行 `npm run g` 全量验证（或依赖 CI integration job 通过）
- [ ] 新增 / 修改纯函数已补充单元测试（`npm test` 通过）
- [ ] `npm run lint` 通过
- [ ] 涉及主题代码、配置或行为变化时已同步 `docs/knowledge/` 并在 `VERIFICATION.md` 登记
- [ ] 涉及发版时已准备 CHANGELOG 章节（`npm run check` 通过）

## 备注


