### PR TITLE
fix(gallery): 修正 albums/posters 在 Firefox/Safari 标题竖排与遮罩消失问题

### DIFF
--- a/source/css/_components/tag-plugins/gallery.styl
+++ b/source/css/_components/tag-plugins/gallery.styl
@@ -94,6 +94,9 @@
       aspect-ratio: 2 / 3
   .grid-cell
     background: var(--block)
+    >.lazy-box
+      width: 100%
+      height: 100%
     img  
       width: 100%
       height: 100%

--- a/source/css/_plugins/lazyload.styl
+++ b/source/css/_plugins/lazyload.styl
@@ -10,6 +10,7 @@ img:not([src])
 
 .lazy-box
   position: relative
+  display: block
   overflow: hidden
   line-height: 0
   &.async // 通过 data-service 异步创建的懒加载元素，没办法知道宽高


### PR DESCRIPTION
## 变更说明

修正 albums 和 posters 标签在 Firefox 和 Safari 下的渲染异常：  
封面标题 .image-caption 竖排显示并溢出卡片范围，显示不出深色遮罩。

<img height="400" alt="Screenshot 2026-08-16 18 22 24_compressed" src="https://github.com/user-attachments/assets/3b82ce42-25ac-49da-95c5-5f0df0540975" />


## 改动范围

- [ ] `layout/`（EJS 模板）
- [ ] `scripts/`（Hexo 标签 / 辅助函数 / 过滤器）
- [x] `source/css/`（Stylus 样式）
- [ ] `source/js/`（浏览器脚本）
- [ ] `languages/`（国际化文案）
- [ ] `docs/`（方案 / 知识库 / 文档）

## 验证清单

- [ ] 涉及 `scripts/` 时已在主工程执行 `npm run g` 全量验证（或依赖 CI integration job 通过）
- [ ] 新增 / 修改纯函数已补充单元测试（`npm test` 通过）
- [ ] `npm run lint` 通过
- [ ] 涉及主题代码、配置或行为变化时已同步 `docs/knowledge/` 并在 `VERIFICATION.md` 登记
- [ ] 涉及发版时已准备 CHANGELOG 章节（`npm run check` 通过）