### PR TITLE
Update waline to 3.15.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -299,9 +299,9 @@ comments:
   # Waline
   # https://waline.js.org/
   waline:
-    js: https://gcore.jsdelivr.net/npm/@waline/client@3.1/dist/waline.js
-    css: https://gcore.jsdelivr.net/npm/@waline/client@3.1/dist/waline.css
-    meta_css: https://gcore.jsdelivr.net/npm/@waline/client@3.1/dist/waline-meta.css
+    js: https://gcore.jsdelivr.net/npm/@waline/client@3.15.2/dist/waline.js
+    css: https://gcore.jsdelivr.net/npm/@waline/client@3.15.2/dist/waline.css
+    meta_css: https://gcore.jsdelivr.net/npm/@waline/client@3.15.2/dist/waline-meta.css
     # Waline server address url, you should set this to your own link
     serverURL: https://waline.vercel.app
     # If false, comment count will only be displayed in post page, not in home page

--- a/source/css/comments/waline.styl
+++ b/source/css/comments/waline.styl
@@ -1,3 +1,7 @@
+@import '../_defines/const'
+@import '../_custom'
+@import '../_defines/func'
+
 .cmt-body
   .wl-panel
     margin: 0.5em 0 !important
@@ -66,3 +70,19 @@
   :root:not([data-theme]) &
     @media (prefers-color-scheme: dark)
       ondark()
+
+// override
+.md-text .cmt-body.waline
+  p
+    line-height: 1.5
+    font-size: var(--waline-font-size)
+    margin: 0
+  .wl-header label, .wl-input
+    font-size: 0.875em
+  .wl-editor
+    font-size: var(--waline-font-size)
+    font-family: $ff-body
+
+.cmt-body.waline .wl-content .wl-reply-to
+  *
+    line-height: 1.5


### PR DESCRIPTION
## 变更说明

- 升级 Waline 客户端至 3.15.2 版本；
- 修改评论区样式更适应主题排版：
    - 评论段落字号改由 --waline-font-size 决定，不再被其他样式覆盖；
    - 评论正文与 reply-to 行高统一为 1.5，包含 reply-to 内 inline-block 链接的行高；
    - 头部标签与输入框字号放大，编辑器使用主题正文字体。

（*style 修改可能比较丑陋，我不大熟悉这些，deepseek 改的。*）