### PR TITLE
fix(ghrepo): 修正卡片统计文本超长时溢出的问题

### DIFF
--- a/source/css/_components/widgets/ghrepo.styl
+++ b/source/css/_components/widgets/ghrepo.styl
@@ -28,3 +28,7 @@
       display: grid
       grid-gap: 2px
       grid-template-columns: repeat(auto-fill, "calc((100% - 2 * %s) / 3)" % 2px)
+      .flex-row
+        min-width: 0
+        span
+          txt-ellipsis()


### PR DESCRIPTION
## 变更说明

给 ghrepo 卡片 .grid 添加截断，以修正 star/fork/tag 文本超长时，内容溢出卡片的问题。

<img height="150" alt="Screenshot" src="https://github.com/user-attachments/assets/88d1023a-cf10-4e6c-b7f6-35af1940a918" />

## 改动范围

- [ ] `layout/`（EJS 模板）
- [ ] `scripts/`（Hexo 标签 / 辅助函数 / 过滤器）
- [x] `source/css/`（Stylus 样式）
- [ ] `source/js/`（浏览器脚本）
- [ ] `languages/`（国际化文案）
- [ ] `docs/`（方案 / 知识库 / 文档）

## 验证清单

- [ ] 涉及 `scripts/` 时已在主工程执行 `npm run g` 全量验证（或依赖 CI integration job 通过）
- [ ] 新增 / 修改纯函数已补充单元测试（`npm test` 通过）
- [ ] `npm run lint` 通过
- [ ] 涉及主题代码、配置或行为变化时已同步 `docs/knowledge/` 并在 `VERIFICATION.md` 登记
- [ ] 涉及发版时已准备 CHANGELOG 章节（`npm run check` 通过）
